### PR TITLE
feat: implement verbose logging with file output and UI controls

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,4 +1,4 @@
-//! # Backup Module
+﻿//! # Backup Module
 //!
 //! Handles creation of `.tar` backup archives
 //!
@@ -13,6 +13,7 @@
 //! - Current format is `.tar`. `.tar.gz` support is planned but not yet active.
 //! - Old `.zip` format is deprecated and left as commented legacy code.
 use crate::helpers::{Progress, get_fingered};
+use crate::dlog;
 use std::{
     fs::File,
     io,
@@ -77,15 +78,18 @@ pub fn backup_gui(
     folders: &[PathBuf],
     output_dir: &Path,
     progress: &Progress,
+    verbose: bool,
 ) -> Result<PathBuf, String> {
-    println!("[DEBUG] backup_gui: Started");
-    println!("[DEBUG] Output directory: {}", output_dir.display());
+    if verbose {
+        dlog!("[DEBUG] backup_gui: Started");
+        dlog!("[DEBUG] Output directory: {}", output_dir.display());
+    }
 
     // Format backup name with timestamp
     let timestamp = Local::now().format("%Y-%m-%d_%H-%M-%S");
     let zip_name = format!("backup_{timestamp}.tar");
     let zip_path = output_dir.join(&zip_name);
-    println!("[DEBUG] Creating backup archive: {}", zip_path.display());
+    if verbose { dlog!("[DEBUG] Creating backup archive: {}", zip_path.display()); }
 
     let tar_file = File::create(&zip_path).map_err(|e| e.to_string())?;
     let mut tar_builder = Builder::new(tar_file);
@@ -98,7 +102,7 @@ pub fn backup_gui(
         .iter()
         .map(|folder| {
             let uuid = Uuid::new_v4();
-            println!("[DEBUG] Assigned UUID {} to {}", uuid, folder.display());
+            if verbose { dlog!("[DEBUG] Assigned UUID {} to {}", uuid, folder.display()); }
             (uuid, folder)
         })
         .collect();
@@ -132,13 +136,13 @@ pub fn backup_gui(
             fingerprint_content.as_bytes(),
         )
         .map_err(|e| e.to_string())?;
-    println!("[DEBUG] fingerprint.txt added to archive");
+    if verbose { dlog!("[DEBUG] fingerprint.txt added to archive"); }
 
     // === Main archive population ===
     for (uuid, original_path) in folder_uuid {
         if original_path.is_file() {
             // Top-level file (not inside folder): encode directly using UUID as name
-            println!("[DEBUG] Adding single file: {}", original_path.display());
+            if verbose { dlog!("[DEBUG] Adding single file: {}", original_path.display()); }
 
             let metadata = original_path.metadata().map_err(|e| e.to_string())?;
             let mut header = Header::new_gnu();
@@ -151,7 +155,7 @@ pub fn backup_gui(
                 Some(ext) => format!("{uuid}.{ext}"),
                 None => uuid.to_string(),
             };
-            println!("[DEBUG] -> Entry name in tar: {entry_name}");
+            if verbose { dlog!("[DEBUG] -> Entry name in tar: {entry_name}"); }
 
             tar_builder
                 .append_data(&mut header, entry_name, &mut f)
@@ -164,7 +168,7 @@ pub fn backup_gui(
         }
 
         // Handle directory entries (recursive walk)
-        println!("[DEBUG] Walking folder: {}", original_path.display());
+        if verbose { dlog!("[DEBUG] Walking folder: {}", original_path.display()); }
 
         for entry in WalkDir::new(original_path)
             .into_iter()
@@ -182,7 +186,7 @@ pub fn backup_gui(
             header.set_cksum();
 
             if metadata.is_file() {
-                println!("[DEBUG] Adding file: {}", entry_path.display());
+                if verbose { dlog!("[DEBUG] Adding file: {}", entry_path.display()); }
                 let mut file = File::open(entry_path).map_err(|e| e.to_string())?;
                 tar_builder
                     .append_data(&mut header, tar_entry_path, &mut file)
@@ -192,7 +196,7 @@ pub fn backup_gui(
                 progress.set(done * 100 / total_files);
             } else if metadata.is_dir() {
                 // Directory entries are included for structure but written as empty
-                println!("[DEBUG] Adding directory: {}", entry_path.display());
+                if verbose { dlog!("[DEBUG] Adding directory: {}", entry_path.display()); }
                 tar_builder
                     .append_data(&mut header, tar_entry_path, io::empty())
                     .map_err(|e| e.to_string())?;
@@ -202,7 +206,7 @@ pub fn backup_gui(
 
     // Finalize and flush .tar structure to disk
     tar_builder.finish().map_err(|e| e.to_string())?;
-    println!("[DEBUG] Archive finished: {}", zip_path.display());
+    if verbose { dlog!("[DEBUG] Archive finished: {}", zip_path.display()); }
 
     progress.done();
 
@@ -267,3 +271,4 @@ pub fn backup_gui(
 //     zip.finish().unwrap();
 //     Ok(zip_path)
 // }
+

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-//! # Helpers Module
+﻿//! # Helpers Module
 //!
 //! Provides shared utilities for the app, including:
 //! - Persistent configuration handling (`KonserveConfig`)
@@ -17,15 +17,67 @@ use egui::CollapsingHeader;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    fs::{self, File},
-    io::Read,
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
     path::{Path, PathBuf},
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU32, Ordering},
     },
 };
+use chrono::Local;
 use tar::Archive;
+
+static DEBUG_LOG: Mutex<Option<File>> = Mutex::new(None);
+
+/// Returns the path of the verbose log file.
+pub fn verbose_log_path() -> PathBuf {
+    KonserveConfig::config_path()
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join("konserve.log")
+}
+
+/// Opens (and truncates) the verbose log file next to the config.
+/// Called when verbose logging is enabled (at startup or when the checkbox is ticked).
+pub fn init_verbose_log() {
+    let path = verbose_log_path();
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+    if let Ok(f) = OpenOptions::new().create(true).truncate(true).write(true).open(&path) {
+        if let Ok(mut guard) = DEBUG_LOG.lock() {
+            *guard = Some(f);
+        }
+    }
+}
+
+/// Closes the log file handle and deletes the log file.
+/// Called when verbose logging is disabled via the checkbox.
+pub fn close_verbose_log() {
+    if let Ok(mut guard) = DEBUG_LOG.lock() {
+        *guard = None;
+    }
+    let _ = fs::remove_file(verbose_log_path());
+}
+
+/// Write a debug message to stdout (if available) and with a timestamp to the log file.
+pub fn write_dlog(msg: &str) {
+    println!("{msg}");
+    if let Ok(mut guard) = DEBUG_LOG.lock() {
+        if let Some(ref mut f) = *guard {
+            let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
+            let _ = writeln!(f, "[{ts}] {msg}");
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! dlog {
+    ($($arg:tt)*) => {
+        $crate::helpers::write_dlog(&format!($($arg)*))
+    }
+}
 
 /// Persistent configuration object for Konserve.
 ///
@@ -91,7 +143,7 @@ impl KonserveConfig {
     /// Priority order for the base directory:
     /// 1. `$XDG_CONFIG_HOME` (preferred)
     /// 2. `$XDG_DATA_HOME` or equivalent data directory
-    /// 3. The user’s home directory
+    /// 3. The user's home directory
     /// 4. Current working directory (`.`) as a fallback
     ///
     /// The final path will always be:
@@ -123,7 +175,6 @@ impl KonserveConfig {
         let path = Self::config_path();
         if let Ok(data) = fs::read_to_string(&path) {
             if let Ok(cfg) = serde_json::from_str(&data) {
-                println!("[DEBUG] Loading config from {}", path.display());
                 return cfg;
             }
         }
@@ -154,7 +205,6 @@ impl KonserveConfig {
                 if let Err(e) = fs::write(&path, json) {
                     eprintln!("[ERROR] Failed to save config: {e}");
                 }
-                println!("[DEBUG] Saved config to {}", path.display());
             }
             Err(e) => {
                 eprintln!("[ERROR] Failed to serialize config: {e}");
@@ -229,26 +279,16 @@ impl Default for Progress {
 /// # Returns
 /// An [`Arc<IconData>`] containing the icon.
 pub fn load_icon_image() -> Arc<IconData> {
-    println!("[DEBUG] load_icon_image: Start");
-
     let image_bytes = include_bytes!("../assets/icon.png");
-    println!("[DEBUG] Icon bytes loaded: {} bytes", image_bytes.len());
-
     let image = image::load_from_memory(image_bytes)
         .expect("Icon image couldn't be loaded")
         .into_rgba8();
-
     let (w, h) = image.dimensions();
-    println!("[DEBUG] Icon dimensions: {w}x{h}");
-
-    let icon_data = Arc::new(IconData {
+    Arc::new(IconData {
         rgba: image.into_raw(),
         width: w,
         height: h,
-    });
-
-    println!("[DEBUG] load_icon_image: Done");
-    icon_data
+    })
 }
 
 /// Recursively toggles the checked state of a folder node and all its children.
@@ -258,16 +298,17 @@ pub fn load_icon_image() -> Arc<IconData> {
 ///
 /// - `node`: The current tree node.
 /// - `checked`: Desired checkbox state.
-fn set_all_checked(node: &mut FolderTreeNode, checked: bool) {
-    println!(
-        "[DEBUG] set_all_checked: Setting node (is_file: {}) to checked = {}",
-        node.is_file, checked
-    );
-
+fn set_all_checked(node: &mut FolderTreeNode, checked: bool, verbose: bool) {
+    if verbose {
+        dlog!(
+            "[DEBUG] set_all_checked: Setting node (is_file: {}) to checked = {}",
+            node.is_file, checked
+        );
+    }
     node.checked = checked;
     for (name, child) in node.children.iter_mut() {
-        println!("[DEBUG]   -> Descending into child: \"{name}\"");
-        set_all_checked(child, checked);
+        if verbose { dlog!("[DEBUG]   -> Descending into child: \"{name}\""); }
+        set_all_checked(child, checked, verbose);
     }
 }
 
@@ -279,7 +320,7 @@ fn set_all_checked(node: &mut FolderTreeNode, checked: bool) {
 /// - `ui`: egui UI handle for rendering.
 /// - `path`: Mutable path stack for recursion.
 /// - `node`: Current folder node to render.
-pub fn render_tree(ui: &mut egui::Ui, path: &mut Vec<String>, node: &mut FolderTreeNode) {
+pub fn render_tree(ui: &mut egui::Ui, path: &mut Vec<String>, node: &mut FolderTreeNode, verbose: bool) {
     for (name, child) in node.children.iter_mut() {
         let mut label = name.clone();
         if !child.is_file {
@@ -299,17 +340,19 @@ pub fn render_tree(ui: &mut egui::Ui, path: &mut Vec<String>, node: &mut FolderT
             // Folder node with children
             ui.horizontal(|ui| {
                 if ui.checkbox(&mut child.checked, "").changed() {
-                    println!(
-                        "[DEBUG] Checkbox changed: setting all children of \"{}\" to {}",
-                        current_path, child.checked
-                    );
-                    set_all_checked(child, child.checked);
+                    if verbose {
+                        dlog!(
+                            "[DEBUG] Checkbox changed: setting all children of \"{}\" to {}",
+                            current_path, child.checked
+                        );
+                    }
+                    set_all_checked(child, child.checked, verbose);
                 }
                 CollapsingHeader::new(label)
                     .default_open(false)
                     .show(ui, |ui| {
                         // Render the children of the current node recursively.
-                        render_tree(ui, path, child);
+                        render_tree(ui, path, child, verbose);
                     });
             });
 
@@ -333,12 +376,13 @@ pub fn render_tree(ui: &mut egui::Ui, path: &mut Vec<String>, node: &mut FolderT
 pub fn build_human_tree(
     entries: Vec<String>,
     path_map: HashMap<String, PathBuf>,
+    verbose: bool,
 ) -> FolderTreeNode {
-    println!("[DEBUG] build_human_tree: Start");
+    if verbose { dlog!("[DEBUG] build_human_tree: Start"); }
     let mut root = FolderTreeNode::default();
 
     for (uuid, original_path) in path_map {
-        println!("[DEBUG] Processing UUID: {uuid}, Path: {original_path:?}");
+        if verbose { dlog!("[DEBUG] Processing UUID: {uuid}, Path: {original_path:?}"); }
 
         let parent_label = original_path
             .parent()
@@ -351,7 +395,7 @@ pub fn build_human_tree(
             .to_string_lossy()
             .to_string();
 
-        println!("[DEBUG] parent_label = \"{parent_label}\", item_name = \"{item_name}\"");
+        if verbose { dlog!("[DEBUG] parent_label = \"{parent_label}\", item_name = \"{item_name}\""); }
 
         let parent_node = root
             .children
@@ -367,23 +411,23 @@ pub fn build_human_tree(
         let is_dir_backup = entries.iter().any(|e| e.starts_with(&dir_prefix)); // Check if there are any entries that start with the UUID prefix.
 
         if is_dir_backup {
-            println!("[DEBUG] Detected directory backup for UUID: {uuid}");
+            if verbose { dlog!("[DEBUG] Detected directory backup for UUID: {uuid}"); }
             parent_node.children.get_mut(&item_name).unwrap().is_file = false;
 
             for tar_path in entries.iter().filter(|e| e.starts_with(&dir_prefix)) {
-                println!("[DEBUG]   tar_path = \"{tar_path}\"");
+                if verbose { dlog!("[DEBUG]   tar_path = \"{tar_path}\""); }
 
                 let rest = tar_path[dir_prefix.len()..].trim_end_matches('/');
                 if rest.is_empty() {
-                    println!("[DEBUG]   Skipping empty rest after trim");
+                    if verbose { dlog!("[DEBUG]   Skipping empty rest after trim"); }
                     continue;
                 }
 
-                println!("[DEBUG]   Rest path: \"{rest}\"");
+                if verbose { dlog!("[DEBUG]   Rest path: \"{rest}\""); }
 
                 let mut cursor = parent_node.children.get_mut(&item_name).unwrap(); // Get the item
                 for part in rest.split('/') {
-                    println!("[DEBUG]     Descending into part: \"{part}\"");
+                    if verbose { dlog!("[DEBUG]     Descending into part: \"{part}\""); }
                     cursor = cursor
                         .children
                         .entry(part.to_string())
@@ -392,27 +436,27 @@ pub fn build_human_tree(
                 cursor.is_file = true;
             }
         } else {
-            println!("[DEBUG] Detected file (not dir) for UUID: {uuid}");
+            if verbose { dlog!("[DEBUG] Detected file (not dir) for UUID: {uuid}"); }
             parent_node.children.get_mut(&item_name).unwrap().is_file = true;
         }
     }
 
-    println!("[DEBUG] build_human_tree: Finished building tree");
+    if verbose { dlog!("[DEBUG] build_human_tree: Finished building tree"); }
     root
 }
 
 /// Recursively traverses a [`FolderTreeNode`] tree,
 /// collecting all checked file paths into a flat list.
-pub fn collect_recursive(node: &FolderTreeNode, path: &mut Vec<String>, output: &mut Vec<String>) {
+pub fn collect_recursive(node: &FolderTreeNode, path: &mut Vec<String>, output: &mut Vec<String>, verbose: bool) {
     for (name, child) in &node.children {
         path.push(name.clone());
         if child.is_file && child.checked {
             let full_path = path.join("/");
-            println!("[DEBUG] collect_recursive: Adding checked file {full_path}");
+            if verbose { dlog!("[DEBUG] collect_recursive: Adding checked file {full_path}"); }
             output.push(full_path);
         }
 
-        collect_recursive(child, path, output);
+        collect_recursive(child, path, output, verbose);
         path.pop();
     }
 }
@@ -420,15 +464,12 @@ pub fn collect_recursive(node: &FolderTreeNode, path: &mut Vec<String>, output: 
 /// Convenience wrapper around [`collect_recursive`].
 ///
 /// Collects all checked paths from the root node.
-pub fn collect_paths(root: &FolderTreeNode) -> Vec<String> {
-    println!("[DEBUG] collect_paths: Start");
+pub fn collect_paths(root: &FolderTreeNode, verbose: bool) -> Vec<String> {
+    if verbose { dlog!("[DEBUG] collect_paths: Start"); }
     let mut result = Vec::new();
     let mut path = Vec::new();
-    collect_recursive(root, &mut path, &mut result);
-    println!(
-        "[DEBUG] collect_paths: Done, collected {} paths",
-        result.len()
-    );
+    collect_recursive(root, &mut path, &mut result, verbose);
+    if verbose { dlog!("[DEBUG] collect_paths: Done, collected {} paths", result.len()); }
     result
 }
 
@@ -442,17 +483,15 @@ pub fn collect_paths(root: &FolderTreeNode) -> Vec<String> {
 /// Returns `Err` if the archive is invalid or fingerprint is missing.
 pub fn parse_fingerprint(
     zip_path: &PathBuf,
+    verbose: bool,
 ) -> Result<(Vec<String>, HashMap<String, PathBuf>), String> {
-    println!(
-        "[DEBUG] parse_fingerprint: Opening archive at {}",
-        zip_path.display()
-    );
+    if verbose { dlog!("[DEBUG] parse_fingerprint: Opening archive at {}", zip_path.display()); }
 
     let file = File::open(zip_path).map_err(|e| e.to_string())?;
     let mut archive = Archive::new(file);
     let mut path_map = HashMap::new();
 
-    println!("[DEBUG] Scanning for fingerprint.txt…");
+    if verbose { dlog!("[DEBUG] Scanning for fingerprint.txt…"); }
 
     // Phase 1: extract fingerprint map
     for entry in archive.entries().map_err(|e| e.to_string())? {
@@ -461,20 +500,20 @@ pub fn parse_fingerprint(
         let name = header_path.to_string_lossy();
 
         if name == "fingerprint.txt" {
-            println!("[DEBUG] Found fingerprint.txt");
+            if verbose { dlog!("[DEBUG] Found fingerprint.txt"); }
             let mut txt = String::new();
             entry.read_to_string(&mut txt).map_err(|e| e.to_string())?;
 
             for line in txt.lines().filter(|l| l.contains(": ")) {
                 let (uuid, p) = line.split_once(": ").unwrap();
-                println!("[DEBUG]   Parsed fingerprint: {} → {}", uuid, p.trim());
+                if verbose { dlog!("[DEBUG]   Parsed fingerprint: {} → {}", uuid, p.trim()); }
                 path_map.insert(uuid.to_string(), PathBuf::from(p.trim()));
             }
             break;
         }
     }
 
-    println!("[DEBUG] Re-opening archive to collect entries");
+    if verbose { dlog!("[DEBUG] Re-opening archive to collect entries"); }
 
     // Phase 2: list remaining archive contents
     let file = File::open(zip_path).map_err(|e| e.to_string())?;
@@ -488,15 +527,17 @@ pub fn parse_fingerprint(
 
         if entry_name != "fingerprint.txt" {
             entries.push(entry_name.clone());
-            println!("[DEBUG]   Found entry: {entry_name}");
+            if verbose { dlog!("[DEBUG]   Found entry: {entry_name}"); }
         }
     }
 
-    println!(
-        "[DEBUG] parse_fingerprint: Done. {} entries, {} fingerprinted",
-        entries.len(),
-        path_map.len()
-    );
+    if verbose {
+        dlog!(
+            "[DEBUG] parse_fingerprint: Done. {} entries, {} fingerprinted",
+            entries.len(),
+            path_map.len()
+        );
+    }
 
     Ok((entries, path_map))
 }
@@ -508,16 +549,9 @@ pub fn parse_fingerprint(
 /// Defaults to `"DEFAULT_FINGERPRINT"` if not set.
 pub fn get_fingered() -> &'static str {
     const DEFAULT: &str = "DEFAULT_FINGERPRINT";
-
     match option_env!("FINGERPRINT") {
-        Some(val) => {
-            println!("get_fingered: using embedded fingerprint = \"{val}\"");
-            val
-        }
-        None => {
-            println!("get_fingered: no embedded fingerprint found, fallback \"{DEFAULT}\"");
-            DEFAULT
-        }
+        Some(val) => val,
+        None => DEFAULT,
     }
 }
 
@@ -531,42 +565,45 @@ pub fn get_fingered() -> &'static str {
 /// - `current_home`: Current user's home directory.
 ///
 /// Returns the adjusted path.
-pub fn adjust_path(original: &Path, current_home: &Path) -> PathBuf {
+pub fn adjust_path(original: &Path, current_home: &Path, verbose: bool) -> PathBuf {
     let og_str = original.to_string_lossy();
     let current_str = current_home.to_string_lossy();
 
-    println!("[DEBUG] adjust_path: original = {og_str}");
-    println!("[DEBUG] adjust_path: current_home = {current_str}");
+    if verbose {
+        dlog!("[DEBUG] adjust_path: original = {og_str}");
+        dlog!("[DEBUG] adjust_path: current_home = {current_str}");
+    }
 
     if og_str.to_lowercase().starts_with("c:\\users\\") {
         let parts: Vec<&str> = og_str.split('\\').collect();
         if parts.len() > 2 {
             let old_username = parts[2];
             let expected_prefix = format!("C:\\Users\\{old_username}");
-            println!("[DEBUG] Detected old user prefix: {expected_prefix}");
+            if verbose { dlog!("[DEBUG] Detected old user prefix: {expected_prefix}"); }
 
             if og_str.starts_with(&expected_prefix) {
                 let rel_path = og_str.strip_prefix(&expected_prefix).unwrap_or("");
                 let adjusted = format!("{current_str}{rel_path}");
-                println!("[DEBUG] Path adjusted: {og_str} → {adjusted}");
+                if verbose { dlog!("[DEBUG] Path adjusted: {og_str} → {adjusted}"); }
                 return PathBuf::from(adjusted);
             }
         }
     }
 
-    println!("[DEBUG] No adjustment needed");
+    if verbose { dlog!("[DEBUG] No adjustment needed"); }
     original.to_path_buf()
 }
 
-pub fn fix_skip(path: &Path) -> Option<PathBuf> {
+pub fn fix_skip(path: &Path, verbose: bool) -> Option<PathBuf> {
     if path.exists() {
         return Some(path.to_path_buf());
     }
     let current_home = dirs::home_dir()?;
-    let adjusted = adjust_path(path, &current_home);
+    let adjusted = adjust_path(path, &current_home, verbose);
     if adjusted.exists() {
         Some(adjusted)
     } else {
         None
     }
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use helpers::fix_skip;
 use helpers::load_icon_image;
 use helpers::parse_fingerprint;
 use helpers::render_tree;
+use helpers::verbose_log_path;
 use restore::restore_backup;
 
 use std::{
@@ -125,13 +126,9 @@ fn build_tree_from_paths(paths: &[String]) -> FolderTreeNode {
 ///
 /// Returns an [`eframe::Error`] if the GUI fails to start.
 fn main() -> Result<(), eframe::Error> {
-    println!("[DEBUG] main: Starting application");
-
     dotenv::dotenv().ok(); // Load environment variables from .env if available
-    println!("[DEBUG] .env loaded (if present)");
 
     let icon = load_icon_image(); // Load application image
-    println!("[DEBUG] Icon loaded");
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -140,16 +137,11 @@ fn main() -> Result<(), eframe::Error> {
             .with_icon(icon),
         ..Default::default()
     };
-    println!("[DEBUG] NativeOptions configured");
 
-    println!("[DEBUG] Launching GUI with run_native");
     eframe::run_native(
         "Konserve",
         options,
-        Box::new(|_cc| {
-            println!("[DEBUG] GUIApp::default() instantiated");
-            Ok(Box::new(GUIApp::default()))
-        }),
+        Box::new(|_cc| Ok(Box::new(GUIApp::default()))),
     )
 }
 
@@ -202,7 +194,7 @@ struct GUIApp {
 impl Default for GUIApp {
     fn default() -> Self {
         let config = helpers::KonserveConfig::load();
-        Self {
+        let app = Self {
             status: Arc::new(Mutex::new("Waiting...".to_string())),
             selected_folders: Vec::new(),
             template_editor: false,
@@ -225,7 +217,11 @@ impl Default for GUIApp {
             automatic_updates: config.automatic_updates,
             file_size_summary: false,
             config,
+        };
+        if app.verbose_logging {
+            helpers::init_verbose_log();
         }
+        app
     }
 }
 
@@ -353,7 +349,7 @@ impl eframe::App for GUIApp {
                     .max_height(300.0)
                     .show(ui, |ui| {
                         let mut current_path = vec![];
-                        render_tree(ui, &mut current_path, &mut self.restore_tree)
+                        render_tree(ui, &mut current_path, &mut self.restore_tree, self.verbose_logging)
                     });
 
                 ui.separator();
@@ -361,18 +357,19 @@ impl eframe::App for GUIApp {
                 if ui.button("Restore selected").clicked() {
                     if let Some(zip_path) = &self.restore_zip_path.clone() {
                         // Collect selected paths from the restore tree
-                        let selected = collect_paths(&self.restore_tree);
+                        let selected = collect_paths(&self.restore_tree, self.verbose_logging);
                         let zip_path = zip_path.clone();
                         let status = self.status.clone();
 
                         let progress = Progress::default();
                         self.restore_progress = Some(progress.clone());
                         self.restore_opening = false;
+                        let verbose = self.verbose_logging;
 
                         thread::spawn(move || {
                             // Show spinner right away
                             if let Err(e) =
-                                restore_backup(&zip_path, Some(selected), status.clone(), &progress)
+                                restore_backup(&zip_path, Some(selected), status.clone(), &progress, verbose)
                             {
                                 *status.lock().unwrap() = format!("❌ Restore failed: {e}");
                             }
@@ -555,8 +552,9 @@ impl eframe::App for GUIApp {
                                                 let mut valid = Vec::new();
                                                 let mut skipped = Vec::new();
 
+                                                let verbose = self.verbose_logging;
                                                 for p in template.paths {
-                                                    match fix_skip(&p) {
+                                                    match fix_skip(&p, verbose) {
                                                         Some(adjusted) => valid.push(adjusted),
                                                         None => skipped.push(p),
                                                     }
@@ -624,6 +622,7 @@ impl eframe::App for GUIApp {
 
                                     let progress = Progress::default();
                                     self.backup_progress = Some(progress.clone());
+                                    let verbose = self.verbose_logging;
 
                                     let out_dir = FileDialog::new()
                                         .set_title("Choose backup destination")
@@ -634,7 +633,7 @@ impl eframe::App for GUIApp {
                                         .stack_size(8 * 1024 * 1024) // 8 MiB
                                     .spawn(move || {
                                             if let Some(out_dir) = out_dir {
-                                                match backup_gui(&folders, &out_dir, &progress) {
+                                                match backup_gui(&folders, &out_dir, &progress, verbose) {
                                                     Ok(path) => {
                                                         *status.lock().unwrap() = format!("✅ Backup created:\n{}", path.display());
                         }
@@ -664,12 +663,13 @@ impl eframe::App for GUIApp {
                                         // This will be used to send the result of the restore operation
                                         let (tx, rx) = mpsc::channel::<RestoreMsg>();
                                         self.restore_rx = Some(rx);
+                                        let verbose = self.verbose_logging;
 
                                         thread::spawn(move || {
-                                            let result: RestoreMsg = parse_fingerprint(&zip_file)
+                                            let result: RestoreMsg = parse_fingerprint(&zip_file, verbose)
                                                 .map(|(entries, map)| {
                                                     (
-                                                        build_human_tree(entries, map),
+                                                        build_human_tree(entries, map, verbose),
                                                         zip_file.clone(),
                                                     )
                                                 });
@@ -745,7 +745,7 @@ impl eframe::App for GUIApp {
                                         self.template_paths = template
                                             .paths
                                             .into_iter()
-                                            .map(|p| fix_skip(&p).unwrap_or(p))
+                                            .map(|p| fix_skip(&p, self.verbose_logging).unwrap_or(p))
                                             .collect();
                                         self.template_editor = true;
                                     } else {
@@ -801,7 +801,25 @@ impl eframe::App for GUIApp {
                             });
                     }
 
-                    ui.checkbox(&mut self.verbose_logging, "Enable Verbose Logging (WIP)");
+                    ui.horizontal(|ui| {
+                        let resp = ui.checkbox(&mut self.verbose_logging, "Enable Verbose Logging");
+                        if resp.changed() {
+                            if self.verbose_logging {
+                                helpers::init_verbose_log();
+                            } else {
+                                helpers::close_verbose_log();
+                            }
+                        }
+                        if self.verbose_logging {
+                            if ui.small_button("Open Log").clicked() {
+                                let path = verbose_log_path();
+                                #[cfg(target_os = "windows")]
+                                let _ = std::process::Command::new("explorer").arg(&path).spawn();
+                                #[cfg(not(target_os = "windows"))]
+                                let _ = std::process::Command::new("open").arg(&path).spawn();
+                            }
+                        }
+                    });
 
                     ui.checkbox(
                         &mut self.automatic_updates,

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1,4 +1,4 @@
-//! Restore module
+﻿//! Restore module
 //!
 //! Handles extraction of `.tar` backups
 //!
@@ -6,6 +6,7 @@
 //! Reconstructs file paths from UUID mappings
 //! Supports restoring either the entire backup or a subset chosen in the UI
 use crate::helpers::{Progress, adjust_path, get_fingered};
+use crate::dlog;
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File},
@@ -55,12 +56,13 @@ fn canon<S: AsRef<str>>(s: S) -> String {
 /// # Notes
 /// - The function looks for a `fingerprint.txt` file inside the archive
 ///   to validate the backup and reconstruct UUID mappings.
-/// - Paths are adapted to the current user’s home directory where needed.
+/// - Paths are adapted to the current user's home directory where needed.
 pub fn restore_backup(
     zip_path: &PathBuf,
     selected: Option<Vec<String>>,
     status: Arc<Mutex<String>>,
     progress: &Progress,
+    verbose: bool,
 ) -> Result<(), String> {
     *status.lock().unwrap() = "Restoring backup…".into();
 
@@ -96,7 +98,7 @@ pub fn restore_backup(
         return Err("Invalid backup fingerprint.".into());
     }
 
-    println!("[fingerprint] loaded, {} uuids", path_map.len());
+    if verbose { dlog!("[fingerprint] loaded, {} uuids", path_map.len()); }
 
     let mut to_extract: HashSet<String> = HashSet::new();
 
@@ -154,13 +156,13 @@ pub fn restore_backup(
 
     let mut done: u32 = 0;
 
-    println!("[select]  to_extract = {to_extract:?}");
+    if verbose { dlog!("[select]  to_extract = {to_extract:?}"); }
 
     // Begin extraction
     let current_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("C:\\"));
     let mut archive = Archive::new(File::open(zip_path).map_err(|e| e.to_string())?);
 
-    println!("[extract] scanning archive…");
+    if verbose { dlog!("[extract] scanning archive…"); }
     let mut restored_count = 0;
 
     for entry_res in archive.entries().map_err(|e| e.to_string())? {
@@ -174,7 +176,7 @@ pub fn restore_backup(
 
         // If selection is archive, skip any non-matching path
         if selected.is_some() && !to_extract.contains(&path_in_tar) {
-            println!("[skip]    {path_in_tar}  (not selected)");
+            if verbose { dlog!("[skip]    {path_in_tar}  (not selected)"); }
             continue;
         }
 
@@ -188,13 +190,13 @@ pub fn restore_backup(
 
         // Case 1: UUID prefix = folder root
         if let Some(orig_base) = path_map.get(&root_component.to_string()) {
-            let adjusted_base = adjust_path(orig_base, &current_home);
+            let adjusted_base = adjust_path(orig_base, &current_home, verbose);
             let rel = tar_path
                 .strip_prefix(Path::new(&root_component as &str))
                 .unwrap_or_else(|_| Path::new(""));
 
             let unpack_to = adjusted_base.join(rel);
-            println!("[write] dir {path_in_tar}  →  {}", unpack_to.display());
+            if verbose { dlog!("[write] dir {path_in_tar}  →  {}", unpack_to.display()); }
 
             if let Some(dir) = unpack_to.parent() {
                 fs::create_dir_all(dir).map_err(|e| e.to_string())?;
@@ -207,8 +209,8 @@ pub fn restore_backup(
         // Case 2: UUID.ext = standalone file
         else if let Some((uuid_part, _ext)) = root_component.split_once('.') {
             if let Some(orig_file) = path_map.get(uuid_part) {
-                let unpack_to = adjust_path(orig_file, &current_home);
-                println!("[write] file {path_in_tar}  →  {}", unpack_to.display());
+                let unpack_to = adjust_path(orig_file, &current_home, verbose);
+                if verbose { dlog!("[write] file {path_in_tar}  →  {}", unpack_to.display()); }
 
                 if let Some(dir) = unpack_to.parent() {
                     fs::create_dir_all(dir).map_err(|e| e.to_string())?;
@@ -218,15 +220,16 @@ pub fn restore_backup(
                 done += 1;
                 progress.set((done * 100) / total_files);
             } else {
-                println!("[skip]    {path_in_tar}  (uuid not in map)");
+                if verbose { dlog!("[skip]    {path_in_tar}  (uuid not in map)"); }
             }
         } else {
-            println!("[skip]    {path_in_tar}  (no handler)");
+            if verbose { dlog!("[skip]    {path_in_tar}  (no handler)"); }
         }
     }
 
-    println!("[done]   restored {restored_count} entries");
+    if verbose { dlog!("[done]   restored {restored_count} entries"); }
     *status.lock().unwrap() = "✅ Restore complete.".into();
     progress.done();
     Ok(())
 }
+


### PR DESCRIPTION
- Gate all debug output behind verbose flag in backup, restore, and helpers
- Write timestamped logs to konserve.log next to config when verbose is enabled
- Create log file immediately on checkbox tick, delete on untick
- Add Open Log button in Settings that appears when verbose is enabled
- Remove always-on startup println calls Closes #3