### PR TITLE
v0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Konserve"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ chrono = "0.4.45"
 dirs = "6.0.0"
 eframe = "0.35.0"
 dotenv = "0.15.0"
-png = "0.18"
+png = "0.18.1"
 rfd = "0.17.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 [dependencies]
 chrono = "0.4.45"
 dirs = "6.0.0"
-eframe = "0.34.3"
+eframe = "0.35.0"
 dotenv = "0.15.0"
 png = "0.18"
 rfd = "0.17.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,7 @@ uuid = { version = "1.23.4", features = ["v4"] }
 
 [dependencies.windows]
 version = ">=0.59, <=0.62"
-features = [
-    "Win32_Foundation",
-    "Win32_System_RestartManager",
-]
+features = ["Win32_Foundation", "Win32_System_RestartManager"]
 
 [build-dependencies]
 embed-resource = "3.0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ walkdir = "2.5.0"
 tar = "0.4.46"
 uuid = { version = "1.23.4", features = ["v4"] }
 
+[dependencies.windows]
+version = ">=0.59, <=0.62"
+features = [
+    "Win32_Foundation",
+    "Win32_System_RestartManager",
+]
+
 [build-dependencies]
 embed-resource = "3.0.9"
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,6 +1,6 @@
-﻿//! Creates `.tar` backup archives with embedded `fingerprint.txt` path mappings.
+﻿//! packs stuff into .tar archives, fingerprint.txt embedded so we can find it all again on restore
 use crate::helpers::{Progress, get_fingered};
-use crate::{clog, dlog};
+use crate::{dlog, elog};
 use std::io::BufWriter;
 use std::{
     fs::File,
@@ -13,8 +13,7 @@ use tar::{Builder, Header};
 use uuid::Uuid;
 use walkdir::WalkDir;
 
-/// Pack the given files/folders into a `.tar` archive with a `fingerprint.txt` inside.
-/// Returns the path to the created archive.
+/// packs the selected files/folders into a .tar with fingerprint.txt embedded, returns the archive path
 pub fn backup_gui(
     folders: &[PathBuf],
     output_dir: &Path,
@@ -38,15 +37,13 @@ pub fn backup_gui(
             "ERROR: failed to create archive {}: {e}",
             zip_path.display()
         );
-        clog!("{msg}");
+        elog!("{msg}");
         msg
     })?;
     let mut tar_builder = Builder::new(BufWriter::new(tar_file));
 
-    // Start the fingerprint with identifier + info section
     let mut fingerprint_content = format!("{}\n[Backup Info]\n", get_fingered());
 
-    // Generate stable UUID mapping for top-level input
     let folder_uuid: Vec<(Uuid, &PathBuf)> = folders
         .iter()
         .map(|folder| {
@@ -60,12 +57,10 @@ pub fn backup_gui(
 
     let mut done = 0u32;
 
-    // Write UUID ↔ original path mappings to fingerprint section
     for (uuid, original_path) in &folder_uuid {
         fingerprint_content.push_str(&format!("{}: {}\n", uuid, original_path.display()));
     }
 
-    // Construct and append fingerprint.txt metadata file
     let mut fingerprint_header = Header::new_gnu();
     fingerprint_header.set_size(fingerprint_content.len() as u64);
     fingerprint_header.set_mode(0o644);
@@ -83,8 +78,8 @@ pub fn backup_gui(
         dlog!("[DEBUG] fingerprint.txt added to archive");
     }
 
-    // Pre-collect all entries so we count and iterate in one filesystem pass.
-    // Each element is (uuid, original_path, walk_entries_or_none).
+    // grab everything up front so we only walk the fs once instead of counting then walking again
+    // each element is (uuid, original_path, walk_entries_or_none)
     let mut all_entries: Vec<(Uuid, &PathBuf, Vec<walkdir::DirEntry>)> = Vec::new();
     let mut total_files: u32 = 0;
 
@@ -103,7 +98,7 @@ pub fn backup_gui(
     }
     let total_files = total_files.max(1);
 
-    // === Main archive population ===
+    // actually building the archive now
     for (uuid, original_path, walk_entries) in all_entries {
         if original_path.is_file() {
             if verbose {
@@ -118,7 +113,7 @@ pub fn backup_gui(
                         progress.set(done * 100 / total_files);
                         continue;
                     }
-                    clog!("ERROR: cannot stat file {}: {e}", original_path.display());
+                    elog!("ERROR: cannot stat file {}: {e}", original_path.display());
                     return Err(e.to_string());
                 }
             };
@@ -138,7 +133,7 @@ pub fn backup_gui(
                         progress.set(done * 100 / total_files);
                         continue;
                     }
-                    clog!("ERROR: cannot open file {}: {e}", original_path.display());
+                    elog!("ERROR: cannot open file {}: {e}", original_path.display());
                     return Err(e.to_string());
                 }
             };
@@ -161,7 +156,7 @@ pub fn backup_gui(
                     progress.set(done * 100 / total_files);
                     continue;
                 }
-                clog!(
+                elog!(
                     "ERROR: failed to write {} to archive: {e}",
                     original_path.display()
                 );
@@ -186,7 +181,7 @@ pub fn backup_gui(
                     if skip_locked {
                         continue;
                     }
-                    clog!("ERROR: cannot stat {}: {e}", entry_path.display());
+                    elog!("ERROR: cannot stat {}: {e}", entry_path.display());
                     return Err(e.to_string());
                 }
             };
@@ -225,7 +220,7 @@ pub fn backup_gui(
                             progress.set(done * 100 / total_files);
                             continue;
                         }
-                        clog!("ERROR: cannot open file {}: {e}", entry_path.display());
+                        elog!("ERROR: cannot open file {}: {e}", entry_path.display());
                         return Err(e.to_string());
                     }
                 };
@@ -239,7 +234,7 @@ pub fn backup_gui(
                         progress.set(done * 100 / total_files);
                         continue;
                     }
-                    clog!(
+                    elog!(
                         "ERROR: failed to write {} to archive: {e}",
                         entry_path.display()
                     );
@@ -261,13 +256,12 @@ pub fn backup_gui(
         }
     }
 
-    // Finalize and flush .tar structure to disk
     tar_builder.finish().map_err(|e| {
         let msg = format!(
             "ERROR: failed to finalize archive {}: {e}",
             zip_path.display()
         );
-        clog!("{msg}");
+        elog!("{msg}");
         msg
     })?;
     if verbose {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -171,7 +171,15 @@ pub fn backup_gui(
             let entry_path = entry.path();
             let metadata = entry.metadata().map_err(|e| e.to_string())?;
 
-            let relative_path = entry_path.strip_prefix(original_path).unwrap();
+            let relative_path = match entry_path.strip_prefix(original_path) {
+    Ok(p) => p,
+    Err(_) => {
+        if verbose {
+            dlog!("[WARN] skipping entry outside original_path: {}", entry_path.display());
+        }
+        continue;
+    }
+};
             let tar_entry_path = Path::new(&uuid.to_string()).join(relative_path);
 
             let mut header = Header::new_gnu();

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,5 +1,5 @@
 ﻿//! Creates `.tar` backup archives with embedded `fingerprint.txt` path mappings.
-use crate::helpers::{Progress, get_fingered};
+use crate::helpers::{get_fingered, Progress};
 use crate::{clog, dlog};
 use std::io::BufWriter;
 use std::{
@@ -172,14 +172,17 @@ pub fn backup_gui(
             let metadata = entry.metadata().map_err(|e| e.to_string())?;
 
             let relative_path = match entry_path.strip_prefix(original_path) {
-    Ok(p) => p,
-    Err(_) => {
-        if verbose {
-            dlog!("[WARN] skipping entry outside original_path: {}", entry_path.display());
-        }
-        continue;
-    }
-};
+                Ok(p) => p,
+                Err(_) => {
+                    if verbose {
+                        dlog!(
+                            "[WARN] skipping entry outside original_path: {}",
+                            entry_path.display()
+                        );
+                    }
+                    continue;
+                }
+            };
             let tar_entry_path = Path::new(&uuid.to_string()).join(relative_path);
 
             let mut header = Header::new_gnu();

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,6 +1,6 @@
 ﻿//! Creates `.tar` backup archives with embedded `fingerprint.txt` path mappings.
 use crate::helpers::{Progress, get_fingered};
-use crate::{dlog, clog};
+use crate::{clog, dlog};
 use std::{
     fs::File,
     io,
@@ -11,7 +11,6 @@ use chrono::Local;
 use tar::{Builder, Header};
 use uuid::Uuid;
 use walkdir::WalkDir;
-
 
 /// Pack the given files/folders into a `.tar` archive with a `fingerprint.txt` inside.
 /// Returns the path to the created archive.
@@ -29,11 +28,17 @@ pub fn backup_gui(
     }
 
     let zip_path = output_dir.join(filename);
-    if verbose { dlog!("[DEBUG] Creating backup archive: {}", zip_path.display()); }
+    if verbose {
+        dlog!("[DEBUG] Creating backup archive: {}", zip_path.display());
+    }
 
     let tar_file = File::create(&zip_path).map_err(|e| {
-        let msg = format!("ERROR: failed to create archive {}: {e}", zip_path.display());
-        clog!("{msg}"); msg
+        let msg = format!(
+            "ERROR: failed to create archive {}: {e}",
+            zip_path.display()
+        );
+        clog!("{msg}");
+        msg
     })?;
     let mut tar_builder = Builder::new(tar_file);
 
@@ -45,7 +50,9 @@ pub fn backup_gui(
         .iter()
         .map(|folder| {
             let uuid = Uuid::new_v4();
-            if verbose { dlog!("[DEBUG] Assigned UUID {} to {}", uuid, folder.display()); }
+            if verbose {
+                dlog!("[DEBUG] Assigned UUID {} to {}", uuid, folder.display());
+            }
             (uuid, folder)
         })
         .collect();
@@ -71,7 +78,9 @@ pub fn backup_gui(
             fingerprint_content.as_bytes(),
         )
         .map_err(|e| e.to_string())?;
-    if verbose { dlog!("[DEBUG] fingerprint.txt added to archive"); }
+    if verbose {
+        dlog!("[DEBUG] fingerprint.txt added to archive");
+    }
 
     // Pre-collect all entries so we count and iterate in one filesystem pass.
     // Each element is (uuid, original_path, walk_entries_or_none).
@@ -96,7 +105,9 @@ pub fn backup_gui(
     // === Main archive population ===
     for (uuid, original_path, walk_entries) in all_entries {
         if original_path.is_file() {
-            if verbose { dlog!("[DEBUG] Adding single file: {}", original_path.display()); }
+            if verbose {
+                dlog!("[DEBUG] Adding single file: {}", original_path.display());
+            }
 
             let metadata = original_path.metadata().map_err(|e| e.to_string())?;
             let mut header = Header::new_gnu();
@@ -107,7 +118,10 @@ pub fn backup_gui(
                 Ok(f) => f,
                 Err(e) => {
                     if skip_locked {
-                        dlog!("[WARN] Skipping inaccessible file {}: {e}", original_path.display());
+                        dlog!(
+                            "[WARN] Skipping inaccessible file {}: {e}",
+                            original_path.display()
+                        );
                         done += 1;
                         progress.set(done * 100 / total_files);
                         continue;
@@ -121,16 +135,24 @@ pub fn backup_gui(
                 Some(ext) => format!("{uuid}.{ext}"),
                 None => uuid.to_string(),
             };
-            if verbose { dlog!("[DEBUG] -> Entry name in tar: {entry_name}"); }
+            if verbose {
+                dlog!("[DEBUG] -> Entry name in tar: {entry_name}");
+            }
 
             if let Err(e) = tar_builder.append_data(&mut header, entry_name, &mut f) {
                 if skip_locked {
-                    dlog!("[WARN] Skipping file {} (write error: {e})", original_path.display());
+                    dlog!(
+                        "[WARN] Skipping file {} (write error: {e})",
+                        original_path.display()
+                    );
                     done += 1;
                     progress.set(done * 100 / total_files);
                     continue;
                 }
-                clog!("ERROR: failed to write {} to archive: {e}", original_path.display());
+                clog!(
+                    "ERROR: failed to write {} to archive: {e}",
+                    original_path.display()
+                );
                 return Err(e.to_string());
             }
 
@@ -140,7 +162,9 @@ pub fn backup_gui(
             continue;
         }
 
-        if verbose { dlog!("[DEBUG] Walking folder: {}", original_path.display()); }
+        if verbose {
+            dlog!("[DEBUG] Walking folder: {}", original_path.display());
+        }
 
         for entry in walk_entries {
             let entry_path = entry.path();
@@ -154,12 +178,17 @@ pub fn backup_gui(
             header.set_cksum();
 
             if metadata.is_file() {
-                if verbose { dlog!("[DEBUG] Adding file: {}", entry_path.display()); }
+                if verbose {
+                    dlog!("[DEBUG] Adding file: {}", entry_path.display());
+                }
                 let mut file = match File::open(entry_path) {
                     Ok(f) => f,
                     Err(e) => {
                         if skip_locked {
-                            dlog!("[WARN] Skipping inaccessible file {}: {e}", entry_path.display());
+                            dlog!(
+                                "[WARN] Skipping inaccessible file {}: {e}",
+                                entry_path.display()
+                            );
                             done += 1;
                             progress.set(done * 100 / total_files);
                             continue;
@@ -170,19 +199,27 @@ pub fn backup_gui(
                 };
                 if let Err(e) = tar_builder.append_data(&mut header, tar_entry_path, &mut file) {
                     if skip_locked {
-                        dlog!("[WARN] Skipping file {} (write error: {e})", entry_path.display());
+                        dlog!(
+                            "[WARN] Skipping file {} (write error: {e})",
+                            entry_path.display()
+                        );
                         done += 1;
                         progress.set(done * 100 / total_files);
                         continue;
                     }
-                    clog!("ERROR: failed to write {} to archive: {e}", entry_path.display());
+                    clog!(
+                        "ERROR: failed to write {} to archive: {e}",
+                        entry_path.display()
+                    );
                     return Err(e.to_string());
                 }
 
                 done += 1;
                 progress.set(done * 100 / total_files);
             } else if metadata.is_dir() {
-                if verbose { dlog!("[DEBUG] Adding directory: {}", entry_path.display()); }
+                if verbose {
+                    dlog!("[DEBUG] Adding directory: {}", entry_path.display());
+                }
                 tar_builder
                     .append_data(&mut header, tar_entry_path, io::empty())
                     .map_err(|e| e.to_string())?;
@@ -192,72 +229,18 @@ pub fn backup_gui(
 
     // Finalize and flush .tar structure to disk
     tar_builder.finish().map_err(|e| {
-        let msg = format!("ERROR: failed to finalize archive {}: {e}", zip_path.display());
-        clog!("{msg}"); msg
+        let msg = format!(
+            "ERROR: failed to finalize archive {}: {e}",
+            zip_path.display()
+        );
+        clog!("{msg}");
+        msg
     })?;
-    if verbose { dlog!("[DEBUG] Archive finished: {}", zip_path.display()); }
+    if verbose {
+        dlog!("[DEBUG] Archive finished: {}", zip_path.display());
+    }
 
     progress.done();
 
     Ok(zip_path)
 }
-
-// --- Legacy ZIP format (deprecated) ---
-//
-//
-// let file = File::create(&zip_path).map_err(|e| e.to_string())?;
-// let mut zip = ZipWriter::new(file);
-// let options: FileOptions<'_, ()> = FileOptions::default().compression_method(
-//     CompressionMethod::Deflated
-// );
-//
-// zip.start_file("fingerprint.txt", options).unwrap();
-// let mut fingerprint = format!("{}\n[Backup Info]\n", get_fingered());
-// for folder in folders {
-//     if let Some(name) = folder.file_name() {
-//         fingerprint.push_str(&format!(
-//             "{}: {}\n",
-//             name.to_string_lossy(),
-//             folder.display()
-//         ));
-//     }
-// }
-//
-// zip.write_all(fingerprint.as_bytes()).unwrap();
-//
-// for path in folders {
-//     if path.is_file() {
-//         let filename = path.file_name().unwrap().to_string_lossy();
-//         zip.start_file(filename, options).unwrap();
-//         let mut f = File::open(path).unwrap();
-//         io::copy(&mut f, &mut zip).unwrap();
-//     } else if path.is_dir() {
-//         for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
-//             let entry_path = entry.path();
-//             let relative = match entry_path.strip_prefix(path) {
-//                 Ok(r) => r,
-//                 Err(_) => {
-//                     continue;
-//                 }
-//             };
-//
-//             let zip_folder = path.file_name().unwrap();
-//             let final_path = Path::new(zip_folder).join(relative);
-//
-//             if entry_path.is_file() {
-//                 zip.start_file(final_path.to_string_lossy(), options)
-//                     .unwrap();
-//                 let mut f = File::open(entry_path).unwrap();
-//                 io::copy(&mut f, &mut zip).unwrap();
-//             } else if !relative.as_os_str().is_empty() {
-//                 zip.add_directory(final_path.to_string_lossy(), options)
-//                     .unwrap();
-//             }
-//         }
-//     }
-//     }
-//
-//     zip.finish().unwrap();
-//     Ok(zip_path)
-// }
-

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,6 +1,7 @@
 ﻿//! Creates `.tar` backup archives with embedded `fingerprint.txt` path mappings.
 use crate::helpers::{Progress, get_fingered};
 use crate::{clog, dlog};
+use std::io::BufWriter;
 use std::{
     fs::File,
     io,
@@ -40,7 +41,7 @@ pub fn backup_gui(
         clog!("{msg}");
         msg
     })?;
-    let mut tar_builder = Builder::new(tar_file);
+    let mut tar_builder = Builder::new(BufWriter::new(tar_file));
 
     // Start the fingerprint with identifier + info section
     let mut fingerprint_content = format!("{}\n[Backup Info]\n", get_fingered());

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,5 +1,5 @@
 ﻿//! Creates `.tar` backup archives with embedded `fingerprint.txt` path mappings.
-use crate::helpers::{get_fingered, Progress};
+use crate::helpers::{Progress, get_fingered};
 use crate::{clog, dlog};
 use std::io::BufWriter;
 use std::{
@@ -110,7 +110,18 @@ pub fn backup_gui(
                 dlog!("[DEBUG] Adding single file: {}", original_path.display());
             }
 
-            let metadata = original_path.metadata().map_err(|e| e.to_string())?;
+            let metadata = match original_path.metadata() {
+                Ok(m) => m,
+                Err(e) => {
+                    if skip_locked {
+                        done += 1;
+                        progress.set(done * 100 / total_files);
+                        continue;
+                    }
+                    clog!("ERROR: cannot stat file {}: {e}", original_path.display());
+                    return Err(e.to_string());
+                }
+            };
             let mut header = Header::new_gnu();
             header.set_metadata(&metadata);
             header.set_cksum();
@@ -169,7 +180,16 @@ pub fn backup_gui(
 
         for entry in walk_entries {
             let entry_path = entry.path();
-            let metadata = entry.metadata().map_err(|e| e.to_string())?;
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(e) => {
+                    if skip_locked {
+                        continue;
+                    }
+                    clog!("ERROR: cannot stat {}: {e}", entry_path.display());
+                    return Err(e.to_string());
+                }
+            };
 
             let relative_path = match entry_path.strip_prefix(original_path) {
                 Ok(p) => p,
@@ -232,9 +252,11 @@ pub fn backup_gui(
                 if verbose {
                     dlog!("[DEBUG] Adding directory: {}", entry_path.display());
                 }
-                tar_builder
-                    .append_data(&mut header, tar_entry_path, io::empty())
-                    .map_err(|e| e.to_string())?;
+                if let Err(e) = tar_builder.append_data(&mut header, tar_entry_path, io::empty())
+                    && !skip_locked
+                {
+                    return Err(e.to_string());
+                }
             }
         }
     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -120,6 +120,8 @@ pub struct KonserveConfig {
     #[serde(default)]
     pub save_template_exe_dir: bool,
     #[serde(default)]
+    pub load_templates_from_exe_dir: bool,
+    #[serde(default)]
     pub backup_name_mode: BackupNameMode,
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -246,8 +246,11 @@ pub fn processes_locking_paths(
             // writes_bytes below fills it before any read
             // and we only read entries RmGetList actually populates
             #[allow(clippy::uninit_vec)]
-            let mut info_buf: Vec<RM_PROCESS_INFO> = Vec::with_capacity(needed as usize);
-            info_buf.set_len(needed as usize);
+            let mut info_buf: Vec<RM_PROCESS_INFO> = {
+                let mut v: Vec<RM_PROCESS_INFO> = Vec::with_capacity(needed as usize);
+                v.set_len(needed as usize);
+                v
+            };
             std::ptr::write_bytes(info_buf.as_mut_ptr(), 0, needed as usize);
 
             let mut actual_count = needed;
@@ -530,9 +533,7 @@ pub fn build_human_tree(
             Some(name) => name.to_string_lossy().to_string(),
             None => {
                 if verbose {
-                    dlog!(
-                        "[WARN] skipping malformed fingerprint entry: {original_path:?}"
-                    );
+                    dlog!("[WARN] skipping malformed fingerprint entry: {original_path:?}");
                 }
                 continue;
             }
@@ -662,7 +663,7 @@ pub fn parse_fingerprint(
         dlog!("[DEBUG] Scanning for fingerprint.txt…");
     }
 
-    // Phase 1: extract fingerprint map
+    // extract fingerprint map
     for entry in archive.entries().map_err(|e| e.to_string())? {
         let mut entry = entry.map_err(|e| e.to_string())?;
         let header_path = entry.path().map_err(|e| e.to_string())?;
@@ -690,7 +691,7 @@ pub fn parse_fingerprint(
         dlog!("[DEBUG] Re-opening archive to collect entries");
     }
 
-    // Phase 2: list remaining archive contents
+    // list remaining archive contents
     let file = File::open(zip_path).map_err(|e| e.to_string())?;
     let mut archive = Archive::new(file);
     let mut entries = Vec::new();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,11 +5,7 @@ use eframe::egui::IconData;
 use egui::CollapsingHeader;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
-    fs::{self, File, OpenOptions},
-    io::{Read, Write},
-    path::{Path, PathBuf},
-    sync::{
+    collections::HashMap, fs::{self, File, OpenOptions}, io::{Read, Write}, path::{Path, PathBuf}, sync::{
         Arc, Mutex,
         atomic::{AtomicU32, Ordering},
     },
@@ -542,3 +538,61 @@ pub fn fix_skip(path: &Path, verbose: bool) -> Option<PathBuf> {
     }
 }
 
+#[cfg(target_os = "windows")]
+pub fn detect_known_processes(process_names: &[&str]) -> Vec<(usize, Option<PathBuf>)> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+    let names_arg = process_names
+        .iter()
+        .map(|n| format!("'{}'", n.trim_end_matches(".exe")))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let script = format!(
+        "Get-Process -Name {names_arg} -ErrorAction SilentlyContinue | \
+         ForEach-Object {{ \"$($_.ProcessName)|$($_.Path)\" }}"
+    );
+
+    let output = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output();
+
+    let mut found = Vec::new();
+    let Ok(output) = output else { return found };
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    for line in text.lines() {
+        let Some((name, path)) = line.split_once('|') else { continue };
+        let name = name.trim();
+        let path = path.trim();
+
+        for (i, proc_name) in process_names.iter().enumerate() {
+            if proc_name.trim_end_matches(".exe").eq_ignore_ascii_case(name) {
+                let exe_path = if path.is_empty() { None } else { Some(PathBuf::from(path)) };
+                found.push((i, exe_path));
+                break;
+            }
+        }
+    }
+    found
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn detect_known_processes(_process_names: &[&str]) -> Vec<(usize, Option<PathBuf>)> {
+    Vec::new()
+}
+
+#[cfg(target_os = "windows")]
+pub fn kill_process(process_name: &str) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    let _ = std::process::Command::new("taskkill")
+    .args(["/f", "/im", process_name])
+    .creation_flags(CREATE_NO_WINDOW)
+    .output();
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn kill_processes(_process_name: &str) {}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -101,6 +101,11 @@ pub fn close_verbose_log() {
     let _ = fs::remove_file(verbose_log_path());
 }
 
+pub fn set_status(status: &Mutex<String>, msg: impl Into<String>) {
+    let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = msg.into();
+}
+
 /// Write a debug message to stdout (if available) and with a timestamp to the log file.
 pub fn write_dlog(msg: &str) {
     println!("{msg}");
@@ -517,11 +522,17 @@ pub fn build_human_tree(
             .unwrap_or(&original_path)
             .display()
             .to_string();
-        let item_name = original_path
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
+        let item_name = match original_path.file_name() {
+            Some(name) => name.to_string_lossy().to_string(),
+            None => {
+                if verbose {
+                    dlog!(
+                        "[WARN] skipping malformed fingerprint entry: {original_path:?}"
+                    );
+                }
+                continue;
+            }
+        };
 
         if verbose {
             dlog!("[DEBUG] parent_label = \"{parent_label}\", item_name = \"{item_name}\"");

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -571,7 +571,14 @@ pub fn detect_known_processes(process_names: &[&str]) -> Vec<(usize, Option<Path
         for (i, proc_name) in process_names.iter().enumerate() {
             if proc_name.trim_end_matches(".exe").eq_ignore_ascii_case(name) {
                 let exe_path = if path.is_empty() { None } else { Some(PathBuf::from(path)) };
-                found.push((i, exe_path));
+                match found.iter_mut().find(|(idx, _): &&mut (usize, Option<PathBuf>)| *idx == i) {
+                    Some((_, existing_path)) => {
+                        if existing_path.is_none() && exe_path.is_some() {
+                            *existing_path = exe_path;
+                        }
+                    }
+                    None => found.push((i, exe_path)),
+                }
                 break;
             }
         }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -592,18 +592,18 @@ pub fn detect_known_processes(_process_names: &[&str]) -> Vec<(usize, Option<Pat
 }
 
 #[cfg(target_os = "windows")]
-pub fn kill_process(process_name: &str) {
+pub fn kill_process(process_name: &str) -> bool {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
-    let _ = std::process::Command::new("taskkill")
+    std::process::Command::new("taskkill")
     .args(["/f", "/im", process_name])
     .creation_flags(CREATE_NO_WINDOW)
     .output()
     .map(|o| o.status.success())
-    .unwrap_or(false);
+    .unwrap_or(false)
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn kill_process(_process_name: &str) {
+pub fn kill_process(_process_name: &str) -> bool {
     false
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -118,6 +118,8 @@ pub struct KonserveConfig {
     #[serde(default)]
     pub save_to_exe_dir: bool,
     #[serde(default)]
+    pub save_template_exe_dir: bool,
+    #[serde(default)]
     pub backup_name_mode: BackupNameMode,
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-﻿//! Shared utilities — config, progress tracking, path helpers, tree rendering, and icon loading.
+﻿//! grab bag of shared stuff: config, progress, path helpers, tree rendering, icon loading
 use crate::FolderTreeNode;
 use chrono::Local;
 use eframe::egui;
@@ -31,7 +31,6 @@ use windows::core::PCWSTR;
 static DEBUG_LOG: Mutex<Option<File>> = Mutex::new(None);
 static CRASH_LOG: Mutex<Option<File>> = Mutex::new(None);
 
-/// Returns the path of the verbose log file.
 pub fn verbose_log_path() -> PathBuf {
     KonserveConfig::config_path()
         .parent()
@@ -39,7 +38,7 @@ pub fn verbose_log_path() -> PathBuf {
         .join("konserve.log")
 }
 
-/// Returns the path of the crash/error log file (next to the exe).
+/// where the crash log lives, next to the exe
 pub fn crash_log_path() -> PathBuf {
     std::env::current_exe()
         .ok()
@@ -47,10 +46,10 @@ pub fn crash_log_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("konserve-crash.log"))
 }
 
-/// No-op — kept so call sites in main.rs don't need changing.
+/// no-op, just here so main.rs doesn't need to change its call site
 pub fn init_crash_log() {}
 
-/// Appends a timestamped message to the crash log, creating the file on first write.
+/// writes a timestamped line to the crash log, creates the file first time
 pub fn write_crash_log(msg: &str) {
     let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
     if let Ok(mut guard) = CRASH_LOG.lock() {
@@ -74,8 +73,42 @@ macro_rules! clog {
     }
 }
 
-/// Opens (and truncates) the verbose log file next to the config.
-/// Called when verbose logging is enabled (at startup or when the checkbox is ticked).
+static ERROR_LOG: Mutex<Option<File>> = Mutex::new(None);
+
+/// where the error dump lives, next to the exe
+pub fn error_log_path() -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.join("konserve-error.log")))
+        .unwrap_or_else(|| PathBuf::from("konserve-error.log"))
+}
+
+/// writes a timestamped line to the error dump, creates the file first time
+/// this is for handled errors, actual panics go to the crash log instead
+pub fn write_error_log(msg: &str) {
+    let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
+    if let Ok(mut guard) = ERROR_LOG.lock() {
+        if guard.is_none() {
+            let path = error_log_path();
+            if let Ok(f) = OpenOptions::new().create(true).append(true).open(&path) {
+                *guard = Some(f);
+            }
+        }
+        if let Some(ref mut f) = *guard {
+            let _ = writeln!(f, "[{ts}] {msg}");
+            let _ = f.flush();
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! elog {
+    ($($arg:tt)*) => {
+        $crate::helpers::write_error_log(&format!($($arg)*))
+    }
+}
+
+/// opens (and wipes) the verbose log next to the config, called on startup or when the checkbox gets ticked
 pub fn init_verbose_log() {
     let path = verbose_log_path();
     if let Some(dir) = path.parent() {
@@ -92,8 +125,7 @@ pub fn init_verbose_log() {
     }
 }
 
-/// Closes the log file handle and deletes the log file.
-/// Called when verbose logging is disabled via the checkbox.
+/// closes the log handle and deletes the file, called when the checkbox gets unticked
 pub fn close_verbose_log() {
     if let Ok(mut guard) = DEBUG_LOG.lock() {
         *guard = None;
@@ -106,7 +138,7 @@ pub fn set_status(status: &Mutex<String>, msg: impl Into<String>) {
     *guard = msg.into();
 }
 
-/// Write a debug message to stdout (if available) and with a timestamp to the log file.
+/// prints to stdout and timestamps into the log file
 pub fn write_dlog(msg: &str) {
     println!("{msg}");
     if let Ok(mut guard) = DEBUG_LOG.lock()
@@ -124,7 +156,7 @@ macro_rules! dlog {
     }
 }
 
-/// Persisted user settings, loaded from and saved to `konserve/config.json`.
+/// user settings, saved to konserve/config.json
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct KonserveConfig {
     #[serde(default)]
@@ -164,7 +196,7 @@ pub fn processes_locking_paths(
     use std::collections::HashSet;
     let mut locked_by: HashSet<String> = HashSet::new();
 
-    // Restart Manager only works on files, so flatten folders to their contents.
+    // restart manager only works on files so flatten folders down to their contents
     let mut files: Vec<PathBuf> = Vec::new();
     for p in paths {
         if p.is_file() {
@@ -189,8 +221,7 @@ pub fn processes_locking_paths(
         );
     }
 
-    // Build null-terminated wide strings for each path.
-    // Must be kept alive for the duration of the unsafe block.
+    // build null-terminated wide strings for each path, gotta stay alive for the whole unsafe block
     let wide_paths: Vec<Vec<u16>> = files
         .iter()
         .map(|p| {
@@ -200,7 +231,7 @@ pub fn processes_locking_paths(
         })
         .collect();
 
-    // PCWSTR is a const pointer — cast from the wide vec pointer.
+    // PCWSTR is just a const pointer cast from the wide vec
     let pcwstrs: Vec<PCWSTR> = wide_paths.iter().map(|w| PCWSTR(w.as_ptr())).collect();
 
     unsafe {
@@ -232,7 +263,7 @@ pub fn processes_locking_paths(
         let mut count: u32 = 0;
         let mut reboot_reasons: u32 = 0;
 
-        // First call with no buffer — just to get `needed` count back.
+        // first call with no buffer, just to find out how big needed is
         let res = RmGetList(
             session,
             &mut needed,
@@ -242,9 +273,8 @@ pub fn processes_locking_paths(
         );
 
         if res == WIN32_ERROR(234) && needed > 0 {
-            // RM_PROCESS_INFO is a plain win32 struct, so zeroing it is fine
-            // writes_bytes below fills it before any read
-            // and we only read entries RmGetList actually populates
+            // RM_PROCESS_INFO is a plain win32 struct so zeroing it is fine, write_bytes below
+            // fills it before we read anything and we only read what RmGetList actually populated
             #[allow(clippy::uninit_vec)]
             let mut info_buf: Vec<RM_PROCESS_INFO> = {
                 let mut v: Vec<RM_PROCESS_INFO> = Vec::with_capacity(needed as usize);
@@ -281,7 +311,7 @@ pub fn processes_locking_paths(
     locked_by
 }
 
-// Stub for non-Windows so the call site in main.rs compiles unconditionally.
+// stub for non-windows so main.rs still compiles
 #[cfg(not(target_os = "windows"))]
 pub fn processes_locking_paths(
     _paths: &[PathBuf],
@@ -291,7 +321,7 @@ pub fn processes_locking_paths(
 }
 
 impl KonserveConfig {
-    /// Resolves `<config_dir>/konserve/config.json`, falling back to data dir, home, then `.`.
+    /// resolves konserve/config.json next to the exe
     fn config_path() -> PathBuf {
         let base = std::env::current_exe()
             .ok()
@@ -301,7 +331,7 @@ impl KonserveConfig {
         base.join("konserve").join("config.json")
     }
 
-    /// Load config from disk, falling back to defaults if missing or invalid.
+    /// loads config from disk, falls back to defaults if it's missing or broken
     pub fn load() -> Self {
         let path = Self::config_path();
         if let Ok(data) = fs::read_to_string(&path)
@@ -312,7 +342,7 @@ impl KonserveConfig {
         Self::default()
     }
 
-    /// Serialize and write the config to disk, creating parent dirs as needed.
+    /// serializes + writes config to disk, makes parent dirs if needed
     pub fn save(&self) -> bool {
         let path = Self::config_path();
         if let Some(dir) = path.parent() {
@@ -323,24 +353,23 @@ impl KonserveConfig {
             Ok(json) => match fs::write(&path, json) {
                 Ok(()) => true,
                 Err(e) => {
-                    eprintln!("[ERROR] Failed to save config: {e}");
+                    write_error_log(&format!("ERROR: failed to save config {}: {e}", path.display()));
                     false
                 }
             },
             Err(e) => {
-                eprintln!("[ERROR] Failed to serialize config: {e}");
+                write_error_log(&format!("ERROR: failed to serialize config: {e}"));
                 false
             }
         }
     }
 }
 
-/// Controls how the backup output filename is generated.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum BackupNameMode {
-    /// Use a strftime-style format string (e.g. `%Y-%m-%d_%H-%M-%S`).
+    /// strftime-style format string
     Timestamp(String),
-    /// Use a fixed plain string as the filename (no timestamp).
+    /// fixed name, no timestamp
     Fixed(String),
 }
 
@@ -350,7 +379,6 @@ impl Default for BackupNameMode {
     }
 }
 
-/// How to handle a file that already exists at the restore destination.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Default)]
 pub enum ConflictResolutionMode {
     #[default]
@@ -360,7 +388,7 @@ pub enum ConflictResolutionMode {
     Rename,
 }
 
-/// Thread-safe progress counter (0–100, or 101 when done).
+/// thread-safe progress counter, 0-100, 101 = done
 #[derive(Clone)]
 pub struct Progress {
     inner: Arc<AtomicU32>,
@@ -374,7 +402,7 @@ impl Progress {
     }
 
     pub fn set(&self, pct: u32) {
-        // Used relaxed ordering, as exact timing isn't critical
+        // relaxed ordering is fine, timing doesn't matter here
         self.inner.store(pct, Ordering::Relaxed);
     }
     pub fn get(&self) -> u32 {
@@ -390,16 +418,7 @@ impl Default for Progress {
     }
 }
 
-/// Loads the Konserve application icon into memory for GUI initialization.
-///
-/// Reads the PNG bytes embedded at compile time (`assets/icon.png`)
-/// and converts them into an [`IconData`] suitable for `eframe`.
-///
-/// # Panics
-/// Panics if the icon cannot be decoded.
-///
-/// # Returns
-/// An [`Arc<IconData>`] containing the icon.
+/// loads the icon (embedded at compile time) into whatever eframe wants, panics if the png is busted
 pub fn load_icon_image() -> Arc<IconData> {
     let image_bytes = include_bytes!("../assets/icon.png");
     let decoder = png::Decoder::new(std::io::Cursor::new(image_bytes));
@@ -413,7 +432,6 @@ pub fn load_icon_image() -> Arc<IconData> {
     let info = reader.next_frame(&mut buf).expect("Icon PNG frame error");
     let bytes = &buf[..info.buffer_size()];
 
-    // Convert RGB to RGBA if needed
     let rgba = match info.color_type {
         png::ColorType::Rgba => bytes.to_vec(),
         png::ColorType::Rgb => bytes
@@ -430,7 +448,7 @@ pub fn load_icon_image() -> Arc<IconData> {
     })
 }
 
-/// Recursively set the checked state of a node and all its children.
+/// checks/unchecks a node and everything under it
 fn set_all_checked(node: &mut FolderTreeNode, checked: bool, verbose: bool) {
     if verbose {
         dlog!(
@@ -448,7 +466,7 @@ fn set_all_checked(node: &mut FolderTreeNode, checked: bool, verbose: bool) {
     }
 }
 
-/// Render a collapsible checkbox tree for the restore selection UI.
+/// draws the collapsible checkbox tree for picking what to restore
 pub fn render_tree(
     ui: &mut egui::Ui,
     path: &mut Vec<String>,
@@ -465,13 +483,11 @@ pub fn render_tree(
         let current_path = path.join("/");
 
         if child.children.is_empty() {
-            // Leaf file node
             ui.horizontal(|ui| {
                 ui.checkbox(&mut child.checked, "");
                 ui.label(label);
             });
         } else {
-            // Folder node with children
             ui.horizontal(|ui| {
                 if ui.checkbox(&mut child.checked, "").changed() {
                     if verbose {
@@ -486,12 +502,12 @@ pub fn render_tree(
                 CollapsingHeader::new(label)
                     .default_open(false)
                     .show(ui, |ui| {
-                        // Render the children of the current node recursively.
+                        // recurse into the children
                         render_tree(ui, path, child, verbose);
                     });
             });
 
-            // Maintain oarent state if any child is still checked
+            // keep parent checked if any child still is
             child.checked = child.children.values().any(|c| c.checked);
         }
 
@@ -499,7 +515,7 @@ pub fn render_tree(
     }
 }
 
-/// Build a human-readable restore tree from tar entries and the UUID → path map.
+/// builds the human-readable restore tree from tar entries + the uuid -> path map
 pub fn build_human_tree(
     entries: Vec<String>,
     path_map: HashMap<String, PathBuf>,
@@ -510,8 +526,8 @@ pub fn build_human_tree(
     }
     let mut root = FolderTreeNode::default();
 
-    // Pre-group entries by UUID prefix so each UUID lookup is O(1) instead of
-    // scanning the full entry list once per UUID.
+    // group entries by uuid prefix up front so lookups are O(1) instead of scanning
+    // the whole entry list every time
     let mut entries_by_uuid: HashMap<String, Vec<String>> = HashMap::new();
     for e in &entries {
         if let Some(slash) = e.find('/') {
@@ -607,7 +623,7 @@ pub fn build_human_tree(
     root
 }
 
-/// Recursively collect all checked file paths into a flat list.
+/// recursively flattens all checked file paths into one list
 pub fn collect_recursive(
     node: &FolderTreeNode,
     path: &mut Vec<String>,
@@ -629,7 +645,7 @@ pub fn collect_recursive(
     }
 }
 
-/// Collect all checked paths from the root node.
+/// collects all checked paths starting from root
 pub fn collect_paths(root: &FolderTreeNode, verbose: bool) -> Vec<String> {
     if verbose {
         dlog!("[DEBUG] collect_paths: Start");
@@ -646,7 +662,7 @@ pub fn collect_paths(root: &FolderTreeNode, verbose: bool) -> Vec<String> {
     result
 }
 
-/// Read `fingerprint.txt` from an archive and return the entry list + UUID map.
+/// reads fingerprint.txt out of the archive, returns entry list + uuid map
 pub fn parse_fingerprint(
     zip_path: &PathBuf,
     verbose: bool,
@@ -666,7 +682,6 @@ pub fn parse_fingerprint(
         dlog!("[DEBUG] Scanning for fingerprint.txt…");
     }
 
-    // extract fingerprint map
     for entry in archive.entries().map_err(|e| e.to_string())? {
         let mut entry = entry.map_err(|e| e.to_string())?;
         let header_path = entry.path().map_err(|e| e.to_string())?;
@@ -694,7 +709,6 @@ pub fn parse_fingerprint(
         dlog!("[DEBUG] Re-opening archive to collect entries");
     }
 
-    // list remaining archive contents
     let file = File::open(zip_path).map_err(|e| e.to_string())?;
     let mut archive = Archive::new(file);
     let mut entries = Vec::new();
@@ -723,7 +737,7 @@ pub fn parse_fingerprint(
     Ok((entries, path_map))
 }
 
-/// The build fingerprint embedded at compile time via the `FINGERPRINT` env var.
+/// fingerprint baked in at compile time from the FINGERPRINT env var
 pub fn get_fingered() -> &'static str {
     const DEFAULT: &str = "DEFAULT_FINGERPRINT";
     match option_env!("FINGERPRINT") {
@@ -732,7 +746,7 @@ pub fn get_fingered() -> &'static str {
     }
 }
 
-/// Remap `C:\Users\<old>` to the current user's home directory if the prefix matches.
+/// swaps C:\Users\<old> for the current user's home dir if it matches
 pub fn adjust_path(original: &Path, current_home: &Path, verbose: bool) -> PathBuf {
     let og_str = original.to_string_lossy();
     let current_str = current_home.to_string_lossy();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -313,20 +313,23 @@ impl KonserveConfig {
     }
 
     /// Serialize and write the config to disk, creating parent dirs as needed.
-    pub fn save(&self) {
+    pub fn save(&self) -> bool {
         let path = Self::config_path();
         if let Some(dir) = path.parent() {
             let _ = fs::create_dir_all(dir);
         }
 
         match serde_json::to_string_pretty(self) {
-            Ok(json) => {
-                if let Err(e) = fs::write(&path, json) {
+            Ok(json) => match fs::write(&path, json) {
+                Ok(()) => true,
+                Err(e) => {
                     eprintln!("[ERROR] Failed to save config: {e}");
+                    false
                 }
-            }
+            },
             Err(e) => {
                 eprintln!("[ERROR] Failed to serialize config: {e}");
+                false
             }
         }
     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -126,9 +126,9 @@ pub struct KonserveConfig {
 impl KonserveConfig {
     /// Resolves `<config_dir>/konserve/config.json`, falling back to data dir, home, then `.`.
     fn config_path() -> PathBuf {
-        let base = dirs::config_dir()
-            .or_else(dirs::data_dir) // fallback
-            .or_else(dirs::home_dir)
+        let base = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
             .unwrap_or(PathBuf::from("."));
 
         base.join("konserve").join("config.json")

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -242,6 +242,10 @@ pub fn processes_locking_paths(
         );
 
         if res == WIN32_ERROR(234) && needed > 0 {
+            // RM_PROCESS_INFO is a plain win32 struct, so zeroing it is fine
+            // writes_bytes below fills it before any read
+            // and we only read entries RmGetList actually populates
+            #[allow(clippy::uninit_vec)]
             let mut info_buf: Vec<RM_PROCESS_INFO> = Vec::with_capacity(needed as usize);
             info_buf.set_len(needed as usize);
             std::ptr::write_bytes(info_buf.as_mut_ptr(), 0, needed as usize);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -125,6 +125,13 @@ pub struct KonserveConfig {
     pub backup_name_mode: BackupNameMode,
 }
 
+ pub fn exe_dir() -> PathBuf {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            .unwrap_or(PathBuf::from("."))
+    }
+
 
 
 impl KonserveConfig {
@@ -137,6 +144,7 @@ impl KonserveConfig {
 
         base.join("konserve").join("config.json")
     }
+
 
     /// Load config from disk, falling back to defaults if missing or invalid.
     pub fn load() -> Self {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,16 +1,20 @@
 ﻿//! Shared utilities — config, progress tracking, path helpers, tree rendering, and icon loading.
 use crate::FolderTreeNode;
+use chrono::Local;
 use eframe::egui;
 use eframe::egui::IconData;
 use egui::CollapsingHeader;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap, fs::{self, File, OpenOptions}, io::{Read, Write}, path::{Path, PathBuf}, sync::{
+    collections::HashMap,
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    sync::{
         Arc, Mutex,
         atomic::{AtomicU32, Ordering},
     },
 };
-use chrono::Local;
 use tar::Archive;
 
 #[cfg(target_os = "windows")]
@@ -77,7 +81,11 @@ pub fn init_verbose_log() {
     if let Some(dir) = path.parent() {
         let _ = fs::create_dir_all(dir);
     }
-    if let Ok(f) = OpenOptions::new().create(true).truncate(true).write(true).open(&path)
+    if let Ok(f) = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&path)
         && let Ok(mut guard) = DEBUG_LOG.lock()
     {
         *guard = Some(f);
@@ -136,15 +144,18 @@ pub struct KonserveConfig {
     pub backup_name_mode: BackupNameMode,
 }
 
- pub fn exe_dir() -> PathBuf {
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
-            .unwrap_or(PathBuf::from("."))
-    }
+pub fn exe_dir() -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        .unwrap_or(PathBuf::from("."))
+}
 
 #[cfg(target_os = "windows")]
-pub fn processes_locking_paths(paths: &[PathBuf], verbose: bool) -> std::collections::HashSet<String> {
+pub fn processes_locking_paths(
+    paths: &[PathBuf],
+    verbose: bool,
+) -> std::collections::HashSet<String> {
     use std::collections::HashSet;
     let mut locked_by: HashSet<String> = HashSet::new();
 
@@ -167,7 +178,10 @@ pub fn processes_locking_paths(paths: &[PathBuf], verbose: bool) -> std::collect
     }
 
     if verbose {
-        dlog!("[DEBUG] RestartManager: scanning {} files for locks", files.len());
+        dlog!(
+            "[DEBUG] RestartManager: scanning {} files for locks",
+            files.len()
+        );
     }
 
     // Build null-terminated wide strings for each path.
@@ -182,10 +196,7 @@ pub fn processes_locking_paths(paths: &[PathBuf], verbose: bool) -> std::collect
         .collect();
 
     // PCWSTR is a const pointer — cast from the wide vec pointer.
-    let pcwstrs: Vec<PCWSTR> = wide_paths
-        .iter()
-        .map(|w| PCWSTR(w.as_ptr()))
-        .collect();
+    let pcwstrs: Vec<PCWSTR> = wide_paths.iter().map(|w| PCWSTR(w.as_ptr())).collect();
 
     unsafe {
         let mut session: u32 = 0;
@@ -260,22 +271,23 @@ pub fn processes_locking_paths(paths: &[PathBuf], verbose: bool) -> std::collect
 
 // Stub for non-Windows so the call site in main.rs compiles unconditionally.
 #[cfg(not(target_os = "windows"))]
-pub fn processes_locking_paths(_paths: &[PathBuf], _verbose: bool) -> std::collections::HashSet<String> {
+pub fn processes_locking_paths(
+    _paths: &[PathBuf],
+    _verbose: bool,
+) -> std::collections::HashSet<String> {
     std::collections::HashSet::new()
 }
-
 
 impl KonserveConfig {
     /// Resolves `<config_dir>/konserve/config.json`, falling back to data dir, home, then `.`.
     fn config_path() -> PathBuf {
         let base = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
             .unwrap_or(PathBuf::from("."));
 
         base.join("konserve").join("config.json")
     }
-
 
     /// Load config from disk, falling back to defaults if missing or invalid.
     pub fn load() -> Self {
@@ -377,7 +389,12 @@ pub fn load_icon_image() -> Arc<IconData> {
     let image_bytes = include_bytes!("../assets/icon.png");
     let decoder = png::Decoder::new(std::io::Cursor::new(image_bytes));
     let mut reader = decoder.read_info().expect("Icon PNG couldn't be read");
-    let mut buf = vec![0u8; reader.output_buffer_size().expect("Icon PNG buffer size unknown")];
+    let mut buf = vec![
+        0u8;
+        reader
+            .output_buffer_size()
+            .expect("Icon PNG buffer size unknown")
+    ];
     let info = reader.next_frame(&mut buf).expect("Icon PNG frame error");
     let bytes = &buf[..info.buffer_size()];
 
@@ -403,18 +420,26 @@ fn set_all_checked(node: &mut FolderTreeNode, checked: bool, verbose: bool) {
     if verbose {
         dlog!(
             "[DEBUG] set_all_checked: Setting node (is_file: {}) to checked = {}",
-            node.is_file, checked
+            node.is_file,
+            checked
         );
     }
     node.checked = checked;
     for (name, child) in node.children.iter_mut() {
-        if verbose { dlog!("[DEBUG]   -> Descending into child: \"{name}\""); }
+        if verbose {
+            dlog!("[DEBUG]   -> Descending into child: \"{name}\"");
+        }
         set_all_checked(child, checked, verbose);
     }
 }
 
 /// Render a collapsible checkbox tree for the restore selection UI.
-pub fn render_tree(ui: &mut egui::Ui, path: &mut Vec<String>, node: &mut FolderTreeNode, verbose: bool) {
+pub fn render_tree(
+    ui: &mut egui::Ui,
+    path: &mut Vec<String>,
+    node: &mut FolderTreeNode,
+    verbose: bool,
+) {
     for (name, child) in node.children.iter_mut() {
         let mut label = name.clone();
         if !child.is_file {
@@ -437,7 +462,8 @@ pub fn render_tree(ui: &mut egui::Ui, path: &mut Vec<String>, node: &mut FolderT
                     if verbose {
                         dlog!(
                             "[DEBUG] Checkbox changed: setting all children of \"{}\" to {}",
-                            current_path, child.checked
+                            current_path,
+                            child.checked
                         );
                     }
                     set_all_checked(child, child.checked, verbose);
@@ -464,7 +490,9 @@ pub fn build_human_tree(
     path_map: HashMap<String, PathBuf>,
     verbose: bool,
 ) -> FolderTreeNode {
-    if verbose { dlog!("[DEBUG] build_human_tree: Start"); }
+    if verbose {
+        dlog!("[DEBUG] build_human_tree: Start");
+    }
     let mut root = FolderTreeNode::default();
 
     // Pre-group entries by UUID prefix so each UUID lookup is O(1) instead of
@@ -480,7 +508,9 @@ pub fn build_human_tree(
     }
 
     for (uuid, original_path) in path_map {
-        if verbose { dlog!("[DEBUG] Processing UUID: {uuid}, Path: {original_path:?}"); }
+        if verbose {
+            dlog!("[DEBUG] Processing UUID: {uuid}, Path: {original_path:?}");
+        }
 
         let parent_label = original_path
             .parent()
@@ -493,7 +523,9 @@ pub fn build_human_tree(
             .to_string_lossy()
             .to_string();
 
-        if verbose { dlog!("[DEBUG] parent_label = \"{parent_label}\", item_name = \"{item_name}\""); }
+        if verbose {
+            dlog!("[DEBUG] parent_label = \"{parent_label}\", item_name = \"{item_name}\"");
+        }
 
         let parent_node = root
             .children
@@ -508,23 +540,33 @@ pub fn build_human_tree(
         let dir_prefix = format!("{uuid}/");
 
         if let Some(uuid_entries) = entries_by_uuid.get(&uuid) {
-            if verbose { dlog!("[DEBUG] Detected directory backup for UUID: {uuid}"); }
+            if verbose {
+                dlog!("[DEBUG] Detected directory backup for UUID: {uuid}");
+            }
             parent_node.children.get_mut(&item_name).unwrap().is_file = false;
 
             for tar_path in uuid_entries {
-                if verbose { dlog!("[DEBUG]   tar_path = \"{tar_path}\""); }
+                if verbose {
+                    dlog!("[DEBUG]   tar_path = \"{tar_path}\"");
+                }
 
                 let rest = tar_path[dir_prefix.len()..].trim_end_matches('/');
                 if rest.is_empty() {
-                    if verbose { dlog!("[DEBUG]   Skipping empty rest after trim"); }
+                    if verbose {
+                        dlog!("[DEBUG]   Skipping empty rest after trim");
+                    }
                     continue;
                 }
 
-                if verbose { dlog!("[DEBUG]   Rest path: \"{rest}\""); }
+                if verbose {
+                    dlog!("[DEBUG]   Rest path: \"{rest}\"");
+                }
 
                 let mut cursor = parent_node.children.get_mut(&item_name).unwrap();
                 for part in rest.split('/') {
-                    if verbose { dlog!("[DEBUG]     Descending into part: \"{part}\""); }
+                    if verbose {
+                        dlog!("[DEBUG]     Descending into part: \"{part}\"");
+                    }
                     cursor = cursor
                         .children
                         .entry(part.to_string())
@@ -533,22 +575,33 @@ pub fn build_human_tree(
                 cursor.is_file = true;
             }
         } else {
-            if verbose { dlog!("[DEBUG] Detected file (not dir) for UUID: {uuid}"); }
+            if verbose {
+                dlog!("[DEBUG] Detected file (not dir) for UUID: {uuid}");
+            }
             parent_node.children.get_mut(&item_name).unwrap().is_file = true;
         }
     }
 
-    if verbose { dlog!("[DEBUG] build_human_tree: Finished building tree"); }
+    if verbose {
+        dlog!("[DEBUG] build_human_tree: Finished building tree");
+    }
     root
 }
 
 /// Recursively collect all checked file paths into a flat list.
-pub fn collect_recursive(node: &FolderTreeNode, path: &mut Vec<String>, output: &mut Vec<String>, verbose: bool) {
+pub fn collect_recursive(
+    node: &FolderTreeNode,
+    path: &mut Vec<String>,
+    output: &mut Vec<String>,
+    verbose: bool,
+) {
     for (name, child) in &node.children {
         path.push(name.clone());
         if child.is_file && child.checked {
             let full_path = path.join("/");
-            if verbose { dlog!("[DEBUG] collect_recursive: Adding checked file {full_path}"); }
+            if verbose {
+                dlog!("[DEBUG] collect_recursive: Adding checked file {full_path}");
+            }
             output.push(full_path);
         }
 
@@ -559,11 +612,18 @@ pub fn collect_recursive(node: &FolderTreeNode, path: &mut Vec<String>, output: 
 
 /// Collect all checked paths from the root node.
 pub fn collect_paths(root: &FolderTreeNode, verbose: bool) -> Vec<String> {
-    if verbose { dlog!("[DEBUG] collect_paths: Start"); }
+    if verbose {
+        dlog!("[DEBUG] collect_paths: Start");
+    }
     let mut result = Vec::new();
     let mut path = Vec::new();
     collect_recursive(root, &mut path, &mut result, verbose);
-    if verbose { dlog!("[DEBUG] collect_paths: Done, collected {} paths", result.len()); }
+    if verbose {
+        dlog!(
+            "[DEBUG] collect_paths: Done, collected {} paths",
+            result.len()
+        );
+    }
     result
 }
 
@@ -572,13 +632,20 @@ pub fn parse_fingerprint(
     zip_path: &PathBuf,
     verbose: bool,
 ) -> Result<(Vec<String>, HashMap<String, PathBuf>), String> {
-    if verbose { dlog!("[DEBUG] parse_fingerprint: Opening archive at {}", zip_path.display()); }
+    if verbose {
+        dlog!(
+            "[DEBUG] parse_fingerprint: Opening archive at {}",
+            zip_path.display()
+        );
+    }
 
     let file = File::open(zip_path).map_err(|e| e.to_string())?;
     let mut archive = Archive::new(file);
     let mut path_map = HashMap::new();
 
-    if verbose { dlog!("[DEBUG] Scanning for fingerprint.txt…"); }
+    if verbose {
+        dlog!("[DEBUG] Scanning for fingerprint.txt…");
+    }
 
     // Phase 1: extract fingerprint map
     for entry in archive.entries().map_err(|e| e.to_string())? {
@@ -587,20 +654,26 @@ pub fn parse_fingerprint(
         let name = header_path.to_string_lossy();
 
         if name == "fingerprint.txt" {
-            if verbose { dlog!("[DEBUG] Found fingerprint.txt"); }
+            if verbose {
+                dlog!("[DEBUG] Found fingerprint.txt");
+            }
             let mut txt = String::new();
             entry.read_to_string(&mut txt).map_err(|e| e.to_string())?;
 
             for line in txt.lines().filter(|l| l.contains(": ")) {
                 let (uuid, p) = line.split_once(": ").unwrap();
-                if verbose { dlog!("[DEBUG]   Parsed fingerprint: {} → {}", uuid, p.trim()); }
+                if verbose {
+                    dlog!("[DEBUG]   Parsed fingerprint: {} → {}", uuid, p.trim());
+                }
                 path_map.insert(uuid.to_string(), PathBuf::from(p.trim()));
             }
             break;
         }
     }
 
-    if verbose { dlog!("[DEBUG] Re-opening archive to collect entries"); }
+    if verbose {
+        dlog!("[DEBUG] Re-opening archive to collect entries");
+    }
 
     // Phase 2: list remaining archive contents
     let file = File::open(zip_path).map_err(|e| e.to_string())?;
@@ -614,7 +687,9 @@ pub fn parse_fingerprint(
 
         if entry_name != "fingerprint.txt" {
             entries.push(entry_name.clone());
-            if verbose { dlog!("[DEBUG]   Found entry: {entry_name}"); }
+            if verbose {
+                dlog!("[DEBUG]   Found entry: {entry_name}");
+            }
         }
     }
 
@@ -653,18 +728,24 @@ pub fn adjust_path(original: &Path, current_home: &Path, verbose: bool) -> PathB
         if parts.len() > 2 {
             let old_username = parts[2];
             let expected_prefix = format!("C:\\Users\\{old_username}");
-            if verbose { dlog!("[DEBUG] Detected old user prefix: {expected_prefix}"); }
+            if verbose {
+                dlog!("[DEBUG] Detected old user prefix: {expected_prefix}");
+            }
 
             if og_str.starts_with(&expected_prefix) {
                 let rel_path = og_str.strip_prefix(&expected_prefix).unwrap_or("");
                 let adjusted = format!("{current_str}{rel_path}");
-                if verbose { dlog!("[DEBUG] Path adjusted: {og_str} → {adjusted}"); }
+                if verbose {
+                    dlog!("[DEBUG] Path adjusted: {og_str} → {adjusted}");
+                }
                 return PathBuf::from(adjusted);
             }
         }
     }
 
-    if verbose { dlog!("[DEBUG] No adjustment needed"); }
+    if verbose {
+        dlog!("[DEBUG] No adjustment needed");
+    }
     original.to_path_buf()
 }
 
@@ -707,14 +788,26 @@ pub fn detect_known_processes(process_names: &[&str]) -> Vec<(usize, Option<Path
     let text = String::from_utf8_lossy(&output.stdout);
 
     for line in text.lines() {
-        let Some((name, path)) = line.split_once('|') else { continue };
+        let Some((name, path)) = line.split_once('|') else {
+            continue;
+        };
         let name = name.trim();
         let path = path.trim();
 
         for (i, proc_name) in process_names.iter().enumerate() {
-            if proc_name.trim_end_matches(".exe").eq_ignore_ascii_case(name) {
-                let exe_path = if path.is_empty() { None } else { Some(PathBuf::from(path)) };
-                match found.iter_mut().find(|(idx, _): &&mut (usize, Option<PathBuf>)| *idx == i) {
+            if proc_name
+                .trim_end_matches(".exe")
+                .eq_ignore_ascii_case(name)
+            {
+                let exe_path = if path.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(path))
+                };
+                match found
+                    .iter_mut()
+                    .find(|(idx, _): &&mut (usize, Option<PathBuf>)| *idx == i)
+                {
                     Some((_, existing_path)) => {
                         if existing_path.is_none() && exe_path.is_some() {
                             *existing_path = exe_path;
@@ -739,11 +832,11 @@ pub fn kill_process(process_name: &str) -> bool {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
     std::process::Command::new("taskkill")
-    .args(["/f", "/im", process_name])
-    .creation_flags(CREATE_NO_WINDOW)
-    .output()
-    .map(|o| o.status.success())
-    .unwrap_or(false)
+        .args(["/f", "/im", process_name])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -36,25 +36,23 @@ pub fn crash_log_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("konserve-crash.log"))
 }
 
-/// Opens (or creates) the crash log file next to the exe.
-/// Called once at startup — always on, no toggle.
-pub fn init_crash_log() {
-    let path = crash_log_path();
-    if let Ok(f) = OpenOptions::new().create(true).append(true).open(&path)
-        && let Ok(mut guard) = CRASH_LOG.lock()
-    {
-        *guard = Some(f);
-    }
-}
+/// No-op — kept so call sites in main.rs don't need changing.
+pub fn init_crash_log() {}
 
-/// Appends a timestamped error or crash message to the crash log.
+/// Appends a timestamped message to the crash log, creating the file on first write.
 pub fn write_crash_log(msg: &str) {
     let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
-    if let Ok(mut guard) = CRASH_LOG.lock()
-        && let Some(ref mut f) = *guard
-    {
-        let _ = writeln!(f, "[{ts}] {msg}");
-        let _ = f.flush();
+    if let Ok(mut guard) = CRASH_LOG.lock() {
+        if guard.is_none() {
+            let path = crash_log_path();
+            if let Ok(f) = OpenOptions::new().create(true).append(true).open(&path) {
+                *guard = Some(f);
+            }
+        }
+        if let Some(ref mut f) = *guard {
+            let _ = writeln!(f, "[{ts}] {msg}");
+            let _ = f.flush();
+        }
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -13,6 +13,17 @@ use std::{
 use chrono::Local;
 use tar::Archive;
 
+#[cfg(target_os = "windows")]
+use std::os::windows::ffi::OsStrExt;
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::WIN32_ERROR;
+#[cfg(target_os = "windows")]
+use windows::Win32::System::RestartManager::{
+    RM_PROCESS_INFO, RmEndSession, RmGetList, RmRegisterResources, RmStartSession,
+};
+#[cfg(target_os = "windows")]
+use windows::core::PCWSTR;
+
 static DEBUG_LOG: Mutex<Option<File>> = Mutex::new(None);
 static CRASH_LOG: Mutex<Option<File>> = Mutex::new(None);
 
@@ -132,6 +143,126 @@ pub struct KonserveConfig {
             .unwrap_or(PathBuf::from("."))
     }
 
+#[cfg(target_os = "windows")]
+pub fn processes_locking_paths(paths: &[PathBuf], verbose: bool) -> std::collections::HashSet<String> {
+    use std::collections::HashSet;
+    let mut locked_by: HashSet<String> = HashSet::new();
+
+    // Restart Manager only works on files, so flatten folders to their contents.
+    let mut files: Vec<PathBuf> = Vec::new();
+    for p in paths {
+        if p.is_file() {
+            files.push(p.clone());
+        } else if p.is_dir() {
+            for entry in walkdir::WalkDir::new(p).into_iter().filter_map(Result::ok) {
+                if entry.file_type().is_file() {
+                    files.push(entry.path().to_path_buf());
+                }
+            }
+        }
+    }
+
+    if files.is_empty() {
+        return locked_by;
+    }
+
+    if verbose {
+        dlog!("[DEBUG] RestartManager: scanning {} files for locks", files.len());
+    }
+
+    // Build null-terminated wide strings for each path.
+    // Must be kept alive for the duration of the unsafe block.
+    let wide_paths: Vec<Vec<u16>> = files
+        .iter()
+        .map(|p| {
+            let mut w: Vec<u16> = p.as_os_str().encode_wide().collect();
+            w.push(0);
+            w
+        })
+        .collect();
+
+    // PCWSTR is a const pointer — cast from the wide vec pointer.
+    let pcwstrs: Vec<PCWSTR> = wide_paths
+        .iter()
+        .map(|w| PCWSTR(w.as_ptr()))
+        .collect();
+
+    unsafe {
+        let mut session: u32 = 0;
+        let mut session_key = [0u16; 33];
+
+        if RmStartSession(
+            &mut session,
+            Some(0u32),
+            windows::core::PWSTR(session_key.as_mut_ptr()),
+        )
+        .is_err()
+        {
+            if verbose {
+                dlog!("[DEBUG] RestartManager: RmStartSession failed");
+            }
+            return locked_by;
+        }
+
+        if RmRegisterResources(session, Some(pcwstrs.as_slice()), None, None).is_err() {
+            if verbose {
+                dlog!("[DEBUG] RestartManager: RmRegisterResources failed");
+            }
+            let _ = RmEndSession(session);
+            return locked_by;
+        }
+
+        let mut needed: u32 = 0;
+        let mut count: u32 = 0;
+        let mut reboot_reasons: u32 = 0;
+
+        // First call with no buffer — just to get `needed` count back.
+        let res = RmGetList(
+            session,
+            &mut needed,
+            &mut count,
+            None,
+            &mut reboot_reasons as *mut u32,
+        );
+
+        if res == WIN32_ERROR(234) && needed > 0 {
+            let mut info_buf: Vec<RM_PROCESS_INFO> = Vec::with_capacity(needed as usize);
+            info_buf.set_len(needed as usize);
+            std::ptr::write_bytes(info_buf.as_mut_ptr(), 0, needed as usize);
+
+            let mut actual_count = needed;
+            let res2 = RmGetList(
+                session,
+                &mut needed,
+                &mut actual_count,
+                Some(info_buf.as_mut_ptr()),
+                &mut reboot_reasons as *mut u32,
+            );
+
+            if res2 == WIN32_ERROR(0) {
+                for info in info_buf.iter().take(actual_count as usize) {
+                    let raw = &info.strAppName;
+                    let len = raw.iter().position(|&c| c == 0).unwrap_or(raw.len());
+                    let name = String::from_utf16_lossy(&raw[..len]);
+                    if verbose {
+                        dlog!("[DEBUG] RestartManager: lock held by \"{}\"", name);
+                    }
+                    locked_by.insert(name.to_lowercase());
+                }
+            }
+        }
+
+        let _ = RmEndSession(session);
+    }
+
+    locked_by
+}
+
+// Stub for non-Windows so the call site in main.rs compiles unconditionally.
+#[cfg(not(target_os = "windows"))]
+pub fn processes_locking_paths(_paths: &[PathBuf], _verbose: bool) -> std::collections::HashSet<String> {
+    std::collections::HashSet::new()
+}
 
 
 impl KonserveConfig {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -598,8 +598,12 @@ pub fn kill_process(process_name: &str) {
     let _ = std::process::Command::new("taskkill")
     .args(["/f", "/im", process_name])
     .creation_flags(CREATE_NO_WINDOW)
-    .output();
+    .output()
+    .map(|o| o.status.success())
+    .unwrap_or(false);
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn kill_processes(_process_name: &str) {}
+pub fn kill_process(_process_name: &str) {
+    false
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,7 @@ struct GUIApp {
     file_size_summary: bool,
     save_to_exe_dir: bool,
     save_template_exe_dir: bool,
+    load_templates_from_exe_dir: bool,
     backup_name_mode: BackupNameMode,
     // temporary string buffer for the name input in settings
     backup_name_input: String,
@@ -230,6 +231,7 @@ impl Default for GUIApp {
             file_size_summary: false,
             save_to_exe_dir: config.save_to_exe_dir,
             save_template_exe_dir: config.save_template_exe_dir,
+            load_templates_from_exe_dir: config.load_templates_from_exe_dir,
             backup_name_input: match &config.backup_name_mode {
                 BackupNameMode::Timestamp(s) | BackupNameMode::Fixed(s) => s.clone(),
             },
@@ -901,8 +903,14 @@ impl eframe::App for GUIApp {
                             ui.add_sized(btn_size, egui::Button::new("Load Template"))
                                 .clicked()
                                 .then(|| {
-                                    if let Some(path) =
+                                    let path = if self.load_templates_from_exe_dir {
+                                        std::env::current_exe().ok()
+                                            .and_then(|p| p.parent().map(|d| d.join("template.json")))
+                                    } else {
                                         FileDialog::new().add_filter("JSON", &["json"]).pick_file()
+                                    };
+
+                                    if let Some(path) = path
                                         && let Ok(data) = fs::read_to_string(&path) {
                                             if let Ok(template) =
                                                 serde_json::from_str::<BackupTemplate>(&data)
@@ -1115,8 +1123,14 @@ impl eframe::App for GUIApp {
                     ui.add_sized(btn_size, egui::Button::new("Edit Template"))
                         .clicked()
                         .then(|| {
-                            if let Some(path) =
+                            let path = if self.load_templates_from_exe_dir {
+                                std::env::current_exe().ok()
+                                    .and_then(|p| p.parent().map(|d| d.join("template.json")))
+                            } else {
                                 FileDialog::new().add_filter("JSON", &["json"]).pick_file()
+                            };
+
+                            if let Some(path) = path
                                 && let Ok(data) = fs::read_to_string(&path) {
                                     if let Ok(template) =
                                         serde_json::from_str::<BackupTemplate>(&data)
@@ -1205,6 +1219,7 @@ impl eframe::App for GUIApp {
 
                         ui.checkbox(&mut self.save_to_exe_dir, "Save backups to exe directory");
                         ui.checkbox(&mut self.save_template_exe_dir, "Save templates to exe directory");
+                        ui.checkbox(&mut self.load_templates_from_exe_dir, "Load templates from exe directory");
                         ui.add_space(2.0);
 
                         ui.label("Default backup location:");
@@ -1308,7 +1323,6 @@ impl eframe::App for GUIApp {
                             Some(std::path::PathBuf::from(&loc_str))
                         };
                     }
-
                     ui.add_space(4.0);
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
@@ -1324,6 +1338,7 @@ impl eframe::App for GUIApp {
                             self.config.file_size_summary = self.file_size_summary;
                             self.config.save_to_exe_dir = self.save_to_exe_dir;
                             self.config.save_template_exe_dir = self.save_template_exe_dir;
+                            self.config.load_templates_from_exe_dir = self.load_templates_from_exe_dir;
                             self.config.backup_name_mode = self.backup_name_mode.clone();
                             self.config.save();
                             *self.status.lock().unwrap() = "✅ Settings saved".into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -671,10 +671,21 @@ impl eframe::App for GUIApp {
                         }
                     }
 
-                    if let Some(apps) = self.relaunch_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
-                        self.relaunch_rx = None;
-                        self.closed_apps = apps;
-                        self.relaunch_prompt = !self.closed_apps.is_empty();
+                    if let Some(rx) = self.relaunch_rx.as_ref() {
+                        use std::sync::mpsc::TryRecvError;
+                        match rx.try_recv() {
+                            Ok(apps) => {
+                                self.relaunch_rx = None;
+                                self.closed_apps = apps;
+                                self.relaunch_prompt = !self.closed_apps.is_empty();
+                            }
+                            Err(TryRecvError::Disconnected) => {
+                                self.relaunch_rx = None;
+                            }
+                            Err(TryRecvError::Empty) => {
+                                // waiting...
+                            }
+                        }
                     }
 
                     // Handle async result from restore preview thread

--- a/src/main.rs
+++ b/src/main.rs
@@ -863,8 +863,14 @@ impl eframe::App for GUIApp {
                         ui.ctx().request_repaint_after(std::time::Duration::from_millis(50));
                     }
 
+                    let dnd_hovering = ui.ctx().input(|i| !i.raw.hovered_files.is_empty());
+
                     // Selected paths card
-                    let stroke = ui.visuals().widgets.noninteractive.bg_stroke;
+                    let stroke = if dnd_hovering {
+                        egui::Stroke::new(2.0, egui::Color32::from_rgb(80, 160, 240))
+                    } else {
+                        ui.visuals().widgets.noninteractive.bg_stroke
+                    };
                     egui::Frame::new()
                         .stroke(stroke)
                         .corner_radius(6.0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use helpers::init_crash_log;
 use helpers::load_icon_image;
 use helpers::parse_fingerprint;
 use helpers::render_tree;
-use helpers::verbose_log_path;
 use helpers::set_status;
+use helpers::verbose_log_path;
 use restore::{ConflictAnswer, restore_backup};
 
 use std::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,10 @@ use std::{
     sync::{Arc, Mutex, mpsc},
     thread,
 };
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
-#[cfg(target_os = "windows")]
-const CREATE_NO_WINDOW: u32 = 0x08000000;
+//#[cfg(target_os = "windows")]
+//use std::os::windows::process::CommandExt;
+//#[cfg(target_os = "windows")]
+//const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 use chrono::Local;
 use eframe::egui;
@@ -42,26 +42,32 @@ struct KnownApp {
     name: &'static str,
     /// Process executable name to detect and kill.
     process: &'static str,
-    /// Executable path to relaunch after backup (Windows only).
-    relaunch: Option<&'static str>,
 }
 
 const KNOWN_APPS: &[KnownApp] = &[
-    KnownApp { name: "Discord / Vesktop", process: "vesktop.exe",    relaunch: None },
-    KnownApp { name: "Discord",           process: "Discord.exe",    relaunch: None },
-    KnownApp { name: "Steam",             process: "steam.exe",      relaunch: Some("C:\\Program Files (x86)\\Steam\\steam.exe") },
-    KnownApp { name: "OBS Studio",        process: "obs64.exe",      relaunch: None },
-    KnownApp { name: "Zen Browser",       process: "zen.exe",        relaunch: None },
-    KnownApp { name: "Spotify",           process: "Spotify.exe",    relaunch: None },
+    KnownApp { name: "Discord / Vesktop", process: "vesktop.exe"},
+    KnownApp { name: "Discord",           process: "Discord.exe"},
+    KnownApp { name: "Steam",             process: "steam.exe"},
+    KnownApp { name: "OBS Studio",        process: "obs64.exe"},
+    KnownApp { name: "Zen Browser",       process: "zen.exe"},
+    KnownApp { name: "Spotify",           process: "Spotify.exe"},
+    KnownApp { name: "ShareX",            process: "ShareX.exe"},
 ];
+
+struct ClosedApp {
+    /// Display name shown in the prompt.
+    name: &'static str,
+    /// Executable path to relaunch after backup (Windows only).
+    exe_path: Option<PathBuf>,
+}
 
 /// Pending backup job waiting on the app-conflict prompt.
 struct PendingBackup {
     folders: Vec<PathBuf>,
     out_dir: PathBuf,
     filename: String,
-    /// Apps that were detected as running.
-    detected: Vec<usize>, // indices into KNOWN_APPS
+    /// Apps detected as running: (index into KNOWN_APPS, captured exe path).
+    detected: Vec<(usize, Option<PathBuf>)>,
 }
 
 /// Result sent from the restore preview thread — tree + archive path on success, error string on failure.
@@ -71,7 +77,7 @@ type RestoreMsg = Result<(FolderTreeNode, PathBuf), String>;
 type FileDialogMsg = Vec<PathBuf>;
 
 /// Result from the background app-detection thread.
-type DetectResult = (Vec<usize>, Vec<PathBuf>, PathBuf, String);
+type DetectResult = (Vec<(usize, Option<PathBuf>)>, Vec<PathBuf>, PathBuf, String);
 
 /// A saved set of paths that can be reloaded for future backups.
 #[derive(Serialize, Deserialize)]
@@ -191,6 +197,9 @@ struct GUIApp {
     pending_backup: Option<PendingBackup>,
     detecting_apps: bool,
     detect_rx: Option<mpsc::Receiver<DetectResult>>,
+    closed_apps: Vec<ClosedApp>,
+    relaunch_prompt: bool,
+    relaunch_rx: Option<mpsc::Receiver<Vec<ClosedApp>>>,
     config: helpers::KonserveConfig,
 }
 
@@ -231,6 +240,9 @@ impl Default for GUIApp {
             pending_backup: None,
             detecting_apps: false,
             detect_rx: None,
+            closed_apps: Vec::new(),
+            relaunch_prompt: false,
+            relaunch_rx: None,
             config,
         };
         if app.verbose_logging {
@@ -253,25 +265,9 @@ impl GUIApp {
         self.detecting_apps = true;
 
         thread::spawn(move || {
-            #[cfg(target_os = "windows")]
-            let detected = {
-                let output = std::process::Command::new("tasklist")
-                    .args(["/fo", "csv", "/nh"])
-                    .creation_flags(CREATE_NO_WINDOW)
-                    .output();
-                match output {
-                    Ok(out) => {
-                        let list = String::from_utf8_lossy(&out.stdout).to_lowercase();
-                        KNOWN_APPS.iter().enumerate()
-                            .filter(|(_, app)| list.contains(&app.process.to_lowercase()))
-                            .map(|(i, _)| i)
-                            .collect::<Vec<_>>()
-                    }
-                    Err(_) => vec![],
-                }
-            };
-            #[cfg(not(target_os = "windows"))]
-            let detected: Vec<usize> = vec![];
+            let process_names: Vec<&'static str> =
+                KNOWN_APPS.iter().map(|a| a.process).collect();
+            let detected = helpers::detect_known_processes(&process_names);
 
             let _ = tx.send((detected, folders, out_dir, filename));
         });
@@ -283,9 +279,7 @@ impl GUIApp {
         folders: Vec<PathBuf>,
         out_dir: PathBuf,
         filename: String,
-        #[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
-        processes: Vec<&'static str>,
-        relaunch: Vec<&'static str>,
+        apps: Vec<ClosedApp>,
     ) {
         let status = self.status.clone();
         let progress = Progress::default();
@@ -294,40 +288,21 @@ impl GUIApp {
 
         *status.lock().unwrap() = "Closing apps…".into();
 
+        let process_names: Vec<&'static str> = apps
+            .iter()
+            .filter_map(|a| KNOWN_APPS.iter().find(|k| k.name == a.name).map(|k| k.process))
+            .collect();
+
+        let (done_tx, done_rx) = mpsc::channel::<Vec<ClosedApp>>();
+        self.relaunch_rx = Some(done_rx);
+
         std::thread::Builder::new()
             .name("konserve-backup".into())
             .stack_size(8 * 1024 * 1024)
             .spawn(move || {
-                #[cfg(target_os = "windows")]
-                // Collect exe paths before killing so we can relaunch afterward.
-                let discovered_relaunch: Vec<String> = {
-                    let mut paths = vec![];
-                    for proc in &processes {
-                        let out = std::process::Command::new("wmic")
-                            .args(["process", "where", &format!("name='{proc}'"), "get", "ExecutablePath", "/value"])
-                            .creation_flags(CREATE_NO_WINDOW)
-                            .output();
-                        if let Ok(out) = out {
-                            let text = String::from_utf8_lossy(&out.stdout);
-                            for line in text.lines() {
-                                if let Some(path) = line.strip_prefix("ExecutablePath=") {
-                                    let path = path.trim();
-                                    if !path.is_empty() {
-                                        paths.push(path.to_string());
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        let _ = std::process::Command::new("taskkill")
-                            .args(["/f", "/im", proc])
-                            .creation_flags(CREATE_NO_WINDOW)
-                            .output();
-                    }
-                    paths
-                };
-                #[cfg(not(target_os = "windows"))]
-                let discovered_relaunch: Vec<String> = vec![];
+                for proc in &process_names {
+                    helpers::kill_process(proc);
+                }
                 std::thread::sleep(std::time::Duration::from_millis(800));
 
                 *status.lock().unwrap() = "Packing into .tar".into();
@@ -340,15 +315,8 @@ impl GUIApp {
                         *status.lock().unwrap() = format!("❌ Backup failed: {e}");
                     }
                 }
-                for exe in &discovered_relaunch {
-                    let _ = std::process::Command::new(exe).spawn();
-                }
-                // Also relaunch any statically configured paths not already covered.
-                for exe in relaunch {
-                    if !discovered_relaunch.iter().any(|d| d.to_lowercase().contains(&exe.to_lowercase())) {
-                        let _ = std::process::Command::new(exe).spawn();
-                    }
-                }
+
+                let _ = done_tx.send(apps);
             })
             .expect("failed to spawn backup thread");
     }
@@ -455,20 +423,20 @@ impl eframe::App for GUIApp {
             if let Some(ref pending) = self.pending_backup {
                 ui.separator();
                 ui.colored_label(egui::Color32::YELLOW, "⚠ The following apps may be locking files:");
-                for &i in &pending.detected {
+                for &(i, _) in &pending.detected {
                     ui.label(format!("  • {}", KNOWN_APPS[i].name));
                 }
                 ui.add_space(4.0);
                 ui.horizontal(|ui| {
                     if ui.button("Close apps & backup").clicked() {
                         let pending = self.pending_backup.take().unwrap();
-                        let processes: Vec<&'static str> = pending.detected.iter()
-                            .map(|&i| KNOWN_APPS[i].process)
+                        let apps: Vec<ClosedApp> = pending.detected.iter()
+                            .map(|&(i, ref path)| ClosedApp {
+                                name: KNOWN_APPS[i].name,
+                                exe_path: path.clone(),
+                            })
                             .collect();
-                        let relaunch: Vec<&'static str> = pending.detected.iter()
-                            .filter_map(|&i| KNOWN_APPS[i].relaunch)
-                            .collect();
-                        self.start_backup_after_kill(pending.folders, pending.out_dir, pending.filename, processes, relaunch);
+                        self.start_backup_after_kill(pending.folders, pending.out_dir, pending.filename, apps);
                     }
                     if ui.button("Skip locked files").clicked() {
                         let pending = self.pending_backup.take().unwrap();
@@ -477,6 +445,32 @@ impl eframe::App for GUIApp {
                     if ui.button("Cancel").clicked() {
                         self.pending_backup = None;
                         *self.status.lock().unwrap() = "❌ Cancelled.".into();
+                    }
+                });
+                ui.separator();
+            }
+
+            if self.relaunch_prompt {
+                ui.separator();
+                ui.colored_label(egui::Color32::LIGHT_BLUE, "Backup finished. Relaunch apps?");
+                for app in &self.closed_apps {
+                    let note = if app.exe_path.is_some() { "" } else { " (failed to relaunch apps)" };
+                    ui.label(format!("  • {}{}", app.name, note));
+                }
+                ui.add_space(4.0);
+                ui.horizontal(|ui| {
+                    if ui.button("yes").clicked() {
+                        for app in &self.closed_apps {
+                            if let Some(path) = &app.exe_path {
+                                let _ = std::process::Command::new(path).spawn();
+                            }
+                        }
+                        self.closed_apps.clear();
+                        self.relaunch_prompt = false;
+                    }
+                    if ui.button("no").clicked() {
+                        self.closed_apps.clear();
+                        self.relaunch_prompt = false;
                     }
                 });
                 ui.separator();
@@ -679,6 +673,12 @@ impl eframe::App for GUIApp {
                             *self.status.lock().unwrap() = "Waiting…".into();
                             self.pending_backup = Some(PendingBackup { folders, out_dir, filename, detected });
                         }
+                    }
+
+                    if let Some(apps) = self.relaunch_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
+                        self.relaunch_rx = None;
+                        self.closed_apps = apps;
+                        self.relaunch_prompt = !self.closed_apps.is_empty();
                     }
 
                     // Handle async result from restore preview thread

--- a/src/main.rs
+++ b/src/main.rs
@@ -1136,7 +1136,7 @@ impl eframe::App for GUIApp {
                                         "Restoring..."
                                     };
                                     ui.label(progress_status);
-                                    ui.ctx().request_repaint_after(std::time::Duration::from_millis(4));
+                                    ui.ctx().request_repaint_after(std::time::Duration::from_millis(33));
                                 }
                                 _ => {
                                     *p_opt = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,7 @@ struct GUIApp {
     relaunch_prompt: bool,
     relaunch_rx: Option<mpsc::Receiver<Vec<ClosedApp>>>,
     config: helpers::KonserveConfig,
+    drop_zone_rect: Option<egui::Rect>,
 }
 
 impl Default for GUIApp {
@@ -248,6 +249,7 @@ impl Default for GUIApp {
             relaunch_prompt: false,
             relaunch_rx: None,
             config,
+            drop_zone_rect: None,
         };
         if app.verbose_logging {
             helpers::init_verbose_log();
@@ -863,15 +865,28 @@ impl eframe::App for GUIApp {
                         ui.ctx().request_repaint_after(std::time::Duration::from_millis(50));
                     }
 
-                    let dnd_hovering = ui.ctx().input(|i| !i.raw.hovered_files.is_empty());
-
+                    let zone_hovering = ui.ctx().input(|i| !i.raw.hovered_files.is_empty());
+                    if zone_hovering {
+                        ui.ctx().request_repaint();
+                    }
+                    let dropped_paths: Vec<PathBuf> = ui.ctx().input(|i| {
+                        i.raw.dropped_files.iter()
+                            .filter_map(|f| f.path.clone())
+                            .collect()
+                    });
+                    if !dropped_paths.is_empty() {
+                        self.selected_folders.extend(dropped_paths);
+                        self.selected_folders.sort();
+                        self.selected_folders.dedup();
+                    }
                     // Selected paths card
-                    let stroke = if dnd_hovering {
+                    let stroke = if zone_hovering {
                         egui::Stroke::new(2.0, egui::Color32::from_rgb(80, 160, 240))
                     } else {
                         ui.visuals().widgets.noninteractive.bg_stroke
                     };
-                    egui::Frame::new()
+
+                    let drop_zone = egui::Frame::new()
                         .stroke(stroke)
                         .corner_radius(6.0)
                         .inner_margin(egui::Margin::symmetric(6, 4))
@@ -880,8 +895,8 @@ impl eframe::App for GUIApp {
                             if self.selected_folders.is_empty() {
                                 ui.vertical_centered(|ui| {
                                     ui.add_space(18.0);
-                                    ui.weak("No files or folders selected.");
-                                    ui.weak("Use Add Folders or Add Files above.");
+                                        ui.weak("No files or folders selected.");
+                                        ui.weak("Use Add Folders or Add Files above, or drag and drop here.");
                                     ui.add_space(18.0);
                                 });
                             } else {
@@ -916,6 +931,9 @@ impl eframe::App for GUIApp {
                                 }
                             }
                         });
+
+                    self.drop_zone_rect = Some(drop_zone.response.rect);
+
                     ui.add_space(2.0);
 
                     ui.separator();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1405,8 +1405,8 @@ impl eframe::App for GUIApp {
                             self.config.save_template_exe_dir = self.save_template_exe_dir;
                             self.config.load_templates_from_exe_dir = self.load_templates_from_exe_dir;
                             self.config.backup_name_mode = self.backup_name_mode.clone();
-                            self.config.save();
-                            *self.status.lock().unwrap() = "✅ Settings saved".into();
+                            let msg = if self.config.save() { "✅ Settings saved" } else { "❌ Failed to save settings" };
+                            *self.status.lock().unwrap() = msg.into();
                             ui.ctx().request_repaint();
                         }
                     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,10 +268,27 @@ impl GUIApp {
         self.detect_rx = Some(rx);
         self.detecting_apps = true;
 
+        let verbose = self.verbose_logging;
         thread::spawn(move || {
+            // Ask Restart Manager which processes hold locks on files inside
+            // the selected backup folders — ignores apps that aren't relevant.
+            let locked_names = helpers::processes_locking_paths(&folders, verbose);
+
             let process_names: Vec<&'static str> =
                 KNOWN_APPS.iter().map(|a| a.process).collect();
-            let detected = helpers::detect_known_processes(&process_names);
+
+            // Only keep apps that are both running AND locking something we're backing up.
+            let detected = helpers::detect_known_processes(&process_names)
+                .into_iter()
+                .filter(|(i, _)| {
+                    let exe_stem = KNOWN_APPS[*i].process
+                        .trim_end_matches(".exe")
+                        .to_lowercase();
+                    locked_names.iter().any(|locked| {
+                        locked.contains(&exe_stem) || exe_stem.contains(locked.as_str())
+                    })
+                })
+                .collect::<Vec<_>>();
 
             let _ = tx.send((detected, folders, out_dir, filename));
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use helpers::load_icon_image;
 use helpers::parse_fingerprint;
 use helpers::render_tree;
 use helpers::verbose_log_path;
+use helpers::set_status;
 use restore::{ConflictAnswer, restore_backup};
 
 use std::{
@@ -304,7 +305,7 @@ impl GUIApp {
         self.backup_progress = Some(progress.clone());
         let verbose = self.verbose_logging;
 
-        *status.lock().unwrap() = "Closing apps…".into();
+        set_status(&status, "Closing apps…");
 
         let (done_tx, done_rx) = mpsc::channel::<Vec<ClosedApp>>();
         self.relaunch_rx = Some(done_rx);
@@ -322,14 +323,14 @@ impl GUIApp {
                 }
                 std::thread::sleep(std::time::Duration::from_millis(800));
 
-                *status.lock().unwrap() = "Packing into .tar".into();
+                set_status(&status, "Packing into .tar");
                 match backup_gui(&folders, &out_dir, &filename, &progress, verbose, false) {
                     Ok(path) => {
-                        *status.lock().unwrap() = format!("✅ Backup created:\n{}", path.display());
+                        set_status(&status, format!("✅ Backup created:\n{}", path.display()));
                     }
                     Err(e) => {
                         clog!("ERROR: backup failed: {e}");
-                        *status.lock().unwrap() = format!("❌ Backup failed: {e}");
+                        set_status(&status, format!("❌ Backup failed: {e}"));
                     }
                 }
 
@@ -351,7 +352,7 @@ impl GUIApp {
         self.backup_progress = Some(progress.clone());
         let verbose = self.verbose_logging;
 
-        *status.lock().unwrap() = "Packing into .tar".into();
+        set_status(&status, "Packing into .tar");
 
         std::thread::Builder::new()
             .name("konserve-backup".into())
@@ -366,11 +367,11 @@ impl GUIApp {
                     skip_locked,
                 ) {
                     Ok(path) => {
-                        *status.lock().unwrap() = format!("✅ Backup created:\n{}", path.display());
+                        set_status(&status, format!("✅ Backup created:\n{}", path.display()));
                     }
                     Err(e) => {
                         clog!("ERROR: backup failed: {e}");
-                        *status.lock().unwrap() = format!("❌ Backup failed: {e}");
+                        set_status(&status, format!("❌ Backup failed: {e}"));
                     }
                 }
             })
@@ -413,19 +414,29 @@ impl eframe::App for GUIApp {
                         let progress = Progress::default();
                         self.backup_progress = Some(progress.clone());
                         let verbose = self.verbose_logging;
-                        let out_dir = dest.parent().unwrap().to_path_buf();
-                        let filename = dest.file_name().unwrap().to_string_lossy().into_owned();
+                        let Some(out_dir) = dest.parent().map(|p| p.to_path_buf()) else {
+                clog!("ERROR: overwrite confirm: dest has no parent: {}", dest.display());
+                set_status(&self.status, "❌ Internal error: invalid path.");
+                self.overwrite_confirm = None;
+                return;
+            };
+            let Some(filename) = dest.file_name().map(|f| f.to_string_lossy().into_owned()) else {
+                clog!("ERROR: overwrite confirm: dest has no filename: {}", dest.display());
+                set_status(&self.status, "❌ Internal error: invalid path.");
+                self.overwrite_confirm = None;
+                return;
+            };
                         self.overwrite_confirm = None;
-                        *status.lock().unwrap() = "Packing into .tar".into();
+                        set_status(&status, "Packing into .tar");
                         std::thread::Builder::new()
                             .name("konserve-backup".into())
                             .stack_size(8 * 1024 * 1024)
                             .spawn(move || {
                                 match backup_gui(&folders, &out_dir, &filename, &progress, verbose, false) {
-                                    Ok(path) => { *status.lock().unwrap() = format!("✅ Backup created:\n{}", path.display()); }
+                                    Ok(path) => { set_status(&status, format!("✅ Backup created:\n{}", path.display())); }
                                     Err(e) => {
                                         clog!("ERROR: backup failed: {e}");
-                                        *status.lock().unwrap() = format!("❌ Backup failed: {e}");
+                                        set_status(&status, format!("❌ Backup failed: {e}"));
                                     }
                                 }
                             })
@@ -480,14 +491,22 @@ impl eframe::App for GUIApp {
                 ui.add_space(4.0);
                 ui.horizontal(|ui| {
                     if ui.button("yes").clicked() {
-                        for app in &self.closed_apps {
-                            if let Some(path) = &app.exe_path {
-                                let _ = std::process::Command::new(path).spawn();
-                            }
-                        }
-                        self.closed_apps.clear();
-                        self.relaunch_prompt = false;
-                    }
+    let mut failed = Vec::new();
+    for app in &self.closed_apps {
+        if let Some(path) = &app.exe_path
+             && let Err(e) = std::process::Command::new(path).spawn() {
+                 clog!("ERROR: failed to relaunch {}: {e}", path.display());
+                 failed.push(KNOWN_APPS[app.known_index].name);
+             }
+    }
+    if failed.is_empty() {
+        set_status(&self.status, "");
+    } else {
+        set_status(&self.status, format!("⚠ Couldn't relaunch: {}", failed.join(", ")));
+    }
+    self.closed_apps.clear();
+    self.relaunch_prompt = false;
+}
                     if ui.button("no").clicked() {
                         self.closed_apps.clear();
                         self.relaunch_prompt = false;
@@ -674,7 +693,7 @@ impl eframe::App for GUIApp {
                             restore_backup(&zip_path, Some(selected), status.clone(), &progress, verbose, mode, conflict_ch)
                         {
                             clog!("ERROR: restore failed: {e}");
-                            *status.lock().unwrap() = format!("❌ Restore failed: {e}");
+                            set_status(&status, format!("❌ Restore failed: {e}"));
                         }
                     });
 
@@ -1029,7 +1048,7 @@ impl eframe::App for GUIApp {
                                     let status = self.status.clone();
 
                                     if folders.is_empty() {
-                                        *status.lock().unwrap() = "❌ Nothing selected.".into();
+                                        set_status(&status, "❌ Nothing selected.");
                                         return;
                                     }
 
@@ -1045,7 +1064,7 @@ impl eframe::App for GUIApp {
                                     };
 
                                     let Some(out_dir) = out_dir else {
-                                        *status.lock().unwrap() = "❌ Cancelled.".into();
+                                        set_status(&status, "❌ Cancelled.");
                                         return;
                                     };
 
@@ -1066,7 +1085,7 @@ impl eframe::App for GUIApp {
                                         return;
                                     }
 
-                                    *status.lock().unwrap() = "Checking for open apps…".into();
+                                    set_status(&status, "Checking for open apps…");
                                     self.spawn_detect_and_backup(folders, out_dir, filename);
     });
                             ui.add_sized(btn_size, egui::Button::new("Restore Backup"))
@@ -1079,7 +1098,7 @@ impl eframe::App for GUIApp {
                                         .pick_file()
                                     {
                                         self.restore_opening = true;
-                                        *status.lock().unwrap() = "⚠ Only restore archives you created yourself — opening archive…".into();
+                                        set_status(&status, "⚠ Only restore archives you created yourself — opening archive…");
 
                                         // Create a progress channel
                                         // This will be used to send the result of the restore operation
@@ -1151,7 +1170,8 @@ impl eframe::App for GUIApp {
                         .inner_margin(egui::Margin::symmetric(8, 4))
                         .show(ui, |ui| {
                             ui.set_width(ui.available_width());
-                            ui.label(self.status.lock().unwrap().as_str());
+                            let status_text = self.status.lock().unwrap_or_else(|e| e.into_inner()).clone();
+                            ui.label(status_text.as_str());
                         });
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! Konserve — simple desktop backup and restore tool.
+//! konserve, backs up your stuff and restores it later
 #![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
 
 mod backup;
@@ -34,11 +34,9 @@ use eframe::egui;
 use rfd::FileDialog;
 use serde::{Deserialize, Serialize};
 
-/// A known app that may lock files during backup.
+/// app that might be locking files during backup
 struct KnownApp {
-    /// Display name shown in the prompt.
     name: &'static str,
-    /// Process executable name to detect and kill.
     process: &'static str,
 }
 
@@ -75,35 +73,35 @@ const KNOWN_APPS: &[KnownApp] = &[
 
 struct ClosedApp {
     known_index: usize,
-    /// Executable path to relaunch after backup (Windows only).
+    /// exe path to relaunch after backup, windows only
     exe_path: Option<PathBuf>,
 }
 
-/// Pending backup job waiting on the app-conflict prompt.
+/// backup job waiting on the app-conflict prompt
 struct PendingBackup {
     folders: Vec<PathBuf>,
     out_dir: PathBuf,
     filename: String,
-    /// Apps detected as running: (index into KNOWN_APPS, captured exe path).
+    /// apps detected running: index into KNOWN_APPS + captured exe path
     detected: Vec<(usize, Option<PathBuf>)>,
 }
 
-/// Result sent from the restore preview thread — tree + archive path on success, error string on failure.
+/// restore preview result: tree + archive path on success, error string on fail
 type RestoreMsg = Result<(FolderTreeNode, PathBuf), String>;
 
-/// Paths returned from a background file dialog.
+/// paths back from a background file dialog
 type FileDialogMsg = Vec<PathBuf>;
 
-/// Result from the background app-detection thread.
+/// result from the background app-detection thread
 type DetectResult = (Vec<(usize, Option<PathBuf>)>, Vec<PathBuf>, PathBuf, String);
 
-/// A saved set of paths that can be reloaded for future backups.
+/// saved paths you can reload for later backups
 #[derive(Serialize, Deserialize)]
 struct BackupTemplate {
     paths: Vec<PathBuf>,
 }
 
-/// One node in the restore tree — either a file or a folder with children.
+/// one node in the restore tree, either a file or a folder with kids
 #[derive(Default)]
 struct FolderTreeNode {
     children: HashMap<String, FolderTreeNode>,
@@ -111,18 +109,13 @@ struct FolderTreeNode {
     is_file: bool,
 }
 
-/// Entry point
-///
-/// Initializes environment variables, loads the application icon,
-/// configures [`eframe::NativeOptions`], and launches the GUI.
-///
-/// Returns an [`eframe::Error`] if the GUI fails to start.
+/// entry point, sets up env vars + icon + eframe and launches the gui
 fn main() -> Result<(), eframe::Error> {
     dotenv::dotenv().ok();
 
     init_crash_log();
 
-    // Catch panics and write them to the crash log before the process dies.
+    // catch panics and dump them to the crash log before we die
     std::panic::set_hook(Box::new(|info| {
         let msg = info.to_string();
         helpers::write_crash_log(&format!("PANIC: {msg}"));
@@ -158,7 +151,7 @@ enum MainTab {
     Settings,
 }
 
-/// All application state — settings, selected paths, progress, and active tab.
+/// all the app state: settings, selected paths, progress, active tab
 struct GUIApp {
     status: Arc<Mutex<String>>,
     selected_folders: Vec<PathBuf>,
@@ -186,7 +179,7 @@ struct GUIApp {
     save_template_exe_dir: bool,
     load_templates_from_exe_dir: bool,
     backup_name_mode: BackupNameMode,
-    // temporary string buffer for the name input in settings
+    // scratch buffer for the name input in settings
     backup_name_input: String,
     overwrite_confirm: Option<PathBuf>,
     conflict_rx: Option<mpsc::Receiver<PathBuf>>,
@@ -255,7 +248,7 @@ impl Default for GUIApp {
 }
 
 impl GUIApp {
-    /// Spawn a background thread to detect conflicting apps, then kick off backup.
+    /// spawns a thread to check for conflicting apps then kicks off the backup
     fn spawn_detect_and_backup(
         &mut self,
         folders: Vec<PathBuf>,
@@ -268,13 +261,13 @@ impl GUIApp {
 
         let verbose = self.verbose_logging;
         thread::spawn(move || {
-            // Ask Restart Manager which processes hold locks on files inside
-            // the selected backup folders — ignores apps that aren't relevant.
+            // ask restart manager what's holding locks on files in the selected folders,
+            // ignore anything not relevant
             let locked_names = helpers::processes_locking_paths(&folders, verbose);
 
             let process_names: Vec<&'static str> = KNOWN_APPS.iter().map(|a| a.process).collect();
 
-            // Only keep apps that are both running AND locking something we're backing up.
+            // only keep apps that are both running and actually locking something we're backing up
             let detected = helpers::detect_known_processes(&process_names)
                 .into_iter()
                 .filter(|(i, _)| {
@@ -292,7 +285,7 @@ impl GUIApp {
         });
     }
 
-    /// Kill apps, wait for them to exit, then start backup — all in a background thread.
+    /// kills apps, waits for them to exit, then starts the backup, all on a background thread
     fn start_backup_after_kill(
         &mut self,
         folders: Vec<PathBuf>,
@@ -329,7 +322,7 @@ impl GUIApp {
                         set_status(&status, format!("✅ Backup created:\n{}", path.display()));
                     }
                     Err(e) => {
-                        clog!("ERROR: backup failed: {e}");
+                        elog!("ERROR: backup failed: {e}");
                         set_status(&status, format!("❌ Backup failed: {e}"));
                     }
                 }
@@ -339,7 +332,7 @@ impl GUIApp {
             .expect("failed to spawn backup thread");
     }
 
-    /// Spawn the backup thread. Called after any app-conflict prompt is resolved.
+    /// spawns the backup thread, called once the app-conflict prompt is resolved
     fn start_backup(
         &mut self,
         folders: Vec<PathBuf>,
@@ -370,7 +363,7 @@ impl GUIApp {
                         set_status(&status, format!("✅ Backup created:\n{}", path.display()));
                     }
                     Err(e) => {
-                        clog!("ERROR: backup failed: {e}");
+                        elog!("ERROR: backup failed: {e}");
                         set_status(&status, format!("❌ Backup failed: {e}"));
                     }
                 }
@@ -402,7 +395,7 @@ impl eframe::App for GUIApp {
             });
             ui.add_space(2.0);
 
-            // Overwrite confirmation dialog for fixed backup names
+            // overwrite confirm for fixed backup names
             if let Some(ref dest) = self.overwrite_confirm.clone() {
                 ui.separator();
                 ui.colored_label(egui::Color32::YELLOW, format!("⚠ '{}' already exists. Overwrite?", dest.file_name().unwrap_or_default().to_string_lossy()));
@@ -415,13 +408,13 @@ impl eframe::App for GUIApp {
                         self.backup_progress = Some(progress.clone());
                         let verbose = self.verbose_logging;
                         let Some(out_dir) = dest.parent().map(|p| p.to_path_buf()) else {
-                clog!("ERROR: overwrite confirm: dest has no parent: {}", dest.display());
+                elog!("ERROR: overwrite confirm: dest has no parent: {}", dest.display());
                 set_status(&self.status, "❌ Internal error: invalid path.");
                 self.overwrite_confirm = None;
                 return;
             };
             let Some(filename) = dest.file_name().map(|f| f.to_string_lossy().into_owned()) else {
-                clog!("ERROR: overwrite confirm: dest has no filename: {}", dest.display());
+                elog!("ERROR: overwrite confirm: dest has no filename: {}", dest.display());
                 set_status(&self.status, "❌ Internal error: invalid path.");
                 self.overwrite_confirm = None;
                 return;
@@ -435,7 +428,7 @@ impl eframe::App for GUIApp {
                                 match backup_gui(&folders, &out_dir, &filename, &progress, verbose, false) {
                                     Ok(path) => { set_status(&status, format!("✅ Backup created:\n{}", path.display())); }
                                     Err(e) => {
-                                        clog!("ERROR: backup failed: {e}");
+                                        elog!("ERROR: backup failed: {e}");
                                         set_status(&status, format!("❌ Backup failed: {e}"));
                                     }
                                 }
@@ -450,7 +443,7 @@ impl eframe::App for GUIApp {
                 ui.separator();
             }
 
-            // App-conflict prompt
+            // app-conflict prompt
             if let Some(ref pending) = self.pending_backup {
                 ui.separator();
                 ui.colored_label(egui::Color32::YELLOW, "⚠ The following apps may be locking files:");
@@ -495,7 +488,7 @@ impl eframe::App for GUIApp {
     for app in &self.closed_apps {
         if let Some(path) = &app.exe_path
              && let Err(e) = std::process::Command::new(path).spawn() {
-                 clog!("ERROR: failed to relaunch {}: {e}", path.display());
+                 elog!("ERROR: failed to relaunch {}: {e}", path.display());
                  failed.push(KNOWN_APPS[app.known_index].name);
              }
     }
@@ -515,7 +508,7 @@ impl eframe::App for GUIApp {
                 ui.separator();
             }
 
-            // Poll restore conflict channel and show per-file prompt
+            // poll the restore conflict channel, show the per-file prompt
             if self.conflict_file.is_none()
                 && let Some(path) = self.conflict_rx.as_ref().and_then(|rx| rx.try_recv().ok())
             {
@@ -565,7 +558,6 @@ impl eframe::App for GUIApp {
                             let mut path_str = path.display().to_string();
 
                             ui.horizontal(|ui| {
-                                // Editable path text field
                                 ui.add_sized(
                                     [240.0, 20.0],
                                     egui::TextEdit::singleline(&mut path_str),
@@ -575,21 +567,18 @@ impl eframe::App for GUIApp {
                                     *path = PathBuf::from(path_str.clone());
                                 }
 
-                                // Excistance indicator
                                 if path.exists() {
                                     ui.label("✅").on_hover_text("This path exists");
                                 } else {
                                     ui.label("❌").on_hover_text("This path does not exist");
                                 }
 
-                                // Browse for folder
                                 if ui.button("Browse").clicked()
                                     && let Some(p) = FileDialog::new().set_directory(exe_dir()).pick_folder()
                                 {
                                     *path = p;
                                 }
 
-                                // Remove path
                                 if ui.button("Remove").clicked() {
                                     to_remove = Some(i);
                                 }
@@ -622,15 +611,18 @@ impl eframe::App for GUIApp {
                             paths: self.template_paths.clone(),
                         };
                         match serde_json::to_string_pretty(&tpl) {
-                            Ok(json) => {
-                                if fs::write(&path, json).is_ok() {
+                            Ok(json) => match fs::write(&path, json) {
+                                Ok(()) => {
                                     *self.status.lock().unwrap() = "✅ Template saved".into();
                                     self.template_editor = false;
-                                } else {
+                                }
+                                Err(e) => {
+                                    elog!("ERROR: failed to write template {}: {e}", path.display());
                                     *self.status.lock().unwrap() = "❌ Couldn't write file.".into();
                                 }
-                            }
-                            Err(_) => {
+                            },
+                            Err(e) => {
+                                elog!("ERROR: failed to serialize template: {e}");
                                 *self.status.lock().unwrap() = "❌ Failed to serialize.".into();
                             }
                         }
@@ -692,7 +684,7 @@ impl eframe::App for GUIApp {
                         if let Err(e) =
                             restore_backup(&zip_path, Some(selected), status.clone(), &progress, verbose, mode, conflict_ch)
                         {
-                            clog!("ERROR: restore failed: {e}");
+                            elog!("ERROR: restore failed: {e}");
                             set_status(&status, format!("❌ Restore failed: {e}"));
                         }
                     });
@@ -713,7 +705,7 @@ impl eframe::App for GUIApp {
 
             match self.tab {
                 MainTab::Home => {
-                    // Poll detect-apps thread result
+                    // poll the detect-apps thread
                     if let Some((detected, folders, out_dir, filename)) =
                         self.detect_rx.as_ref().and_then(|rx| rx.try_recv().ok())
                     {
@@ -744,13 +736,13 @@ impl eframe::App for GUIApp {
                         }
                     }
 
-                    // Handle async result from restore preview thread
+                    // handle the restore preview thread's result
                     if let Some(finished_msg) =
                         self.restore_rx.as_ref().and_then(|rx| rx.try_recv().ok())
                     {
                         match finished_msg {
                             Ok((mut tree, zip)) => {
-                                // Recursively check all nodes in the tree
+                                // checks every node in the tree
                                 fn check_all(n: &mut FolderTreeNode) {
                                     n.checked = true;
                                     for c in n.children.values_mut() {
@@ -766,7 +758,7 @@ impl eframe::App for GUIApp {
                                 *self.status.lock().unwrap() = String::new();
                             }
                             Err(e) => {
-                                clog!("ERROR: failed to open archive: {e}");
+                                elog!("ERROR: failed to open archive: {e}");
                                 *self.status.lock().unwrap() = format!("❌ Failed to open archive: {e}");
                             }
                         }
@@ -803,7 +795,7 @@ impl eframe::App for GUIApp {
                     ui.separator();
                     ui.add_space(2.0);
 
-                    // Folder and File Pickers
+                    // folder + file pickers
                     egui::Frame::new()
                         .fill(ui.visuals().faint_bg_color)
                         .corner_radius(6.0)
@@ -814,7 +806,7 @@ impl eframe::App for GUIApp {
                         if ui.button("Add Folders").clicked() {
                             #[cfg(target_os = "macos")]
                             {
-                                // macOS wants dialogs on the main thread
+                                // macos wants dialogs on the main thread
                                 if let Some(folders) = FileDialog::new().set_directory(exe_dir()).pick_folders() {
                                     self.selected_folders.extend(folders);
                                     self.selected_folders.sort();
@@ -824,7 +816,7 @@ impl eframe::App for GUIApp {
 
                             #[cfg(not(target_os = "macos"))]
                             {
-                                // Linux / Windows: run dialog in a background thread
+                                // linux/windows: run the dialog on a background thread
                                 if self.file_dialog_rx.is_none() {
                                     self.file_dialog_opening = true;
 
@@ -900,7 +892,7 @@ impl eframe::App for GUIApp {
                         self.selected_folders.sort();
                         self.selected_folders.dedup();
                     }
-                    // Selected paths card
+                    // selected paths card
                     let stroke = if zone_hovering {
                         egui::Stroke::new(2.0, egui::Color32::from_rgb(80, 160, 240))
                     } else {
@@ -959,7 +951,7 @@ impl eframe::App for GUIApp {
 
                     ui.separator();
 
-                    // Template and Action Buttons
+                    // template + action buttons
                     ui.horizontal(|ui| {
                         ui.vertical(|ui| {
                             let btn_size = egui::vec2(110.0, 24.0);
@@ -973,41 +965,47 @@ impl eframe::App for GUIApp {
                                         FileDialog::new().set_directory(exe_dir()).add_filter("JSON", &["json"]).pick_file()
                                     };
 
-                                    if let Some(path) = path
-                                        && let Ok(data) = fs::read_to_string(&path) {
-                                            if let Ok(template) =
-                                                serde_json::from_str::<BackupTemplate>(&data)
-                                            {
-                                                let mut valid = Vec::new();
-                                                let mut skipped = Vec::new();
+                                    if let Some(path) = path {
+                                        match fs::read_to_string(&path) {
+                                            Ok(data) => match serde_json::from_str::<BackupTemplate>(&data) {
+                                                Ok(template) => {
+                                                    let mut valid = Vec::new();
+                                                    let mut skipped = Vec::new();
 
-                                                let verbose = self.verbose_logging;
-                                                for p in template.paths {
-                                                    match fix_skip(&p, verbose) {
-                                                        Some(adjusted) => valid.push(adjusted),
-                                                        None => skipped.push(p),
+                                                    let verbose = self.verbose_logging;
+                                                    for p in template.paths {
+                                                        match fix_skip(&p, verbose) {
+                                                            Some(adjusted) => valid.push(adjusted),
+                                                            None => skipped.push(p),
+                                                        }
                                                     }
+
+                                                    self.selected_folders = valid;
+                                                    let msg = if skipped.is_empty() {
+                                                        "✅ Template loaded".into()
+                                                    } else {
+                                                        // tell them how many got skipped
+                                                        format!(
+                                                            "✅ Loaded with {} paths skipped",
+                                                            skipped.len()
+                                                        )
+                                                    };
+
+                                                    *self.status.lock().unwrap() = msg;
                                                 }
-
-                                                // Sort and deduplicate the paths
-                                                self.selected_folders = valid;
-                                                // Sort the paths
-                                                let msg = if skipped.is_empty() {
-                                                    "✅ Template loaded".into()
-                                                } else {
-                                                    // If there are skipped paths, show how many were skipped
-                                                    format!(
-                                                        "✅ Loaded with {} paths skipped",
-                                                        skipped.len()
-                                                    )
-                                                };
-
-                                                *self.status.lock().unwrap() = msg;
-                                            } else {
+                                                Err(e) => {
+                                                    elog!("ERROR: failed to parse template {}: {e}", path.display());
+                                                    *self.status.lock().unwrap() =
+                                                        "❌ Bad template format.".into();
+                                                }
+                                            },
+                                            Err(e) => {
+                                                elog!("ERROR: failed to read template {}: {e}", path.display());
                                                 *self.status.lock().unwrap() =
-                                                    "❌ Bad template format.".into();
+                                                    "❌ Couldn't read template file.".into();
                                             }
                                         }
+                                    }
                                 });
 
                                 ui.add_sized(btn_size, egui::Button::new("Save Template"))
@@ -1025,13 +1023,22 @@ impl eframe::App for GUIApp {
                                             paths: self.selected_folders.clone(),
                                         };
 
-                                        if let Ok(json) = serde_json::to_string_pretty(&template) {
-                                            if fs::write(&path, json).is_ok() {
+                                        match serde_json::to_string_pretty(&template) {
+                                            Ok(json) => match fs::write(&path, json) {
+                                                Ok(()) => {
+                                                    *self.status.lock().unwrap() =
+                                                        "✅ Template saved.".into();
+                                                }
+                                                Err(e) => {
+                                                    elog!("ERROR: failed to write template {}: {e}", path.display());
+                                                    *self.status.lock().unwrap() =
+                                                        "❌ Failed to write template.".into();
+                                                }
+                                            },
+                                            Err(e) => {
+                                                elog!("ERROR: failed to serialize template: {e}");
                                                 *self.status.lock().unwrap() =
-                                                    "✅ Template saved.".into();
-                                            } else {
-                                                *self.status.lock().unwrap() =
-                                                    "❌ Failed to write template.".into();
+                                                    "❌ Failed to serialize template.".into();
                                             }
                                         }
                                     }
@@ -1043,7 +1050,6 @@ impl eframe::App for GUIApp {
                                 .fill(egui::Color32::from_rgb(40, 100, 180)))
                                 .clicked()
                                 .then(|| {
-                                    // Check if any folders are selected
                                     let folders = self.selected_folders.clone();
                                     let status = self.status.clone();
 
@@ -1052,7 +1058,7 @@ impl eframe::App for GUIApp {
                                         return;
                                     }
 
-                                    // Resolve output directory
+                                    // figure out where to save it
                                     let out_dir = if self.save_to_exe_dir {
                                         std::env::current_exe().ok()
                                             .and_then(|p| p.parent().map(|d| d.to_path_buf()))
@@ -1068,7 +1074,7 @@ impl eframe::App for GUIApp {
                                         return;
                                     };
 
-                                    // Resolve filename
+                                    // figure out the filename
                                     let filename = match &self.backup_name_mode {
                                         BackupNameMode::Timestamp(fmt) => {
                                             format!("backup_{}.tar", Local::now().format(fmt))
@@ -1078,7 +1084,7 @@ impl eframe::App for GUIApp {
                                         }
                                     };
 
-                                    // Check for overwrite if fixed name
+                                    // check for overwrite if it's a fixed name
                                     let dest = out_dir.join(&filename);
                                     if matches!(self.backup_name_mode, BackupNameMode::Fixed(_)) && dest.exists() {
                                         self.overwrite_confirm = Some(dest);
@@ -1100,8 +1106,6 @@ impl eframe::App for GUIApp {
                                         self.restore_opening = true;
                                         set_status(&status, "⚠ Only restore archives you created yourself — opening archive…");
 
-                                        // Create a progress channel
-                                        // This will be used to send the result of the restore operation
                                         let (tx, rx) = mpsc::channel::<RestoreMsg>();
                                         self.restore_rx = Some(rx);
                                         let verbose = self.verbose_logging;
@@ -1114,7 +1118,6 @@ impl eframe::App for GUIApp {
                                                         zip_file.clone(),
                                                     )
                                                 });
-                                            // Send the result back to the main thread
                                             let _ = tx.send(result);
                                         });
                                     }
@@ -1195,22 +1198,30 @@ impl eframe::App for GUIApp {
                                 FileDialog::new().set_directory(exe_dir()).add_filter("JSON", &["json"]).pick_file()
                             };
 
-                            if let Some(path) = path
-                                && let Ok(data) = fs::read_to_string(&path) {
-                                    if let Ok(template) =
-                                        serde_json::from_str::<BackupTemplate>(&data)
-                                    {
-                                        self.template_paths = template
-                                            .paths
-                                            .into_iter()
-                                            .map(|p| fix_skip(&p, self.verbose_logging).unwrap_or(p))
-                                            .collect();
-                                        self.template_editor = true;
-                                    } else {
+                            if let Some(path) = path {
+                                match fs::read_to_string(&path) {
+                                    Ok(data) => match serde_json::from_str::<BackupTemplate>(&data) {
+                                        Ok(template) => {
+                                            self.template_paths = template
+                                                .paths
+                                                .into_iter()
+                                                .map(|p| fix_skip(&p, self.verbose_logging).unwrap_or(p))
+                                                .collect();
+                                            self.template_editor = true;
+                                        }
+                                        Err(e) => {
+                                            elog!("ERROR: failed to parse template {}: {e}", path.display());
+                                            *self.status.lock().unwrap() =
+                                                "❌ Couldn't parse template.".into();
+                                        }
+                                    },
+                                    Err(e) => {
+                                        elog!("ERROR: failed to read template {}: {e}", path.display());
                                         *self.status.lock().unwrap() =
-                                            "❌ Couldn't parse template.".into();
+                                            "❌ Couldn't read template file.".into();
                                     }
                                 }
+                            }
                         });
 
                     ui.add_space(4.0);
@@ -1226,7 +1237,7 @@ impl eframe::App for GUIApp {
                         .map(|p| p.display().to_string())
                         .unwrap_or_default();
 
-                    // --- General ---
+                    // --- general ---
                     frame.show(ui, |ui| {
                         ui.set_width(ui.available_width());
                         ui.label(egui::RichText::new("General").weak().small());
@@ -1251,7 +1262,7 @@ impl eframe::App for GUIApp {
 
                     ui.add_space(4.0);
 
-                    // --- Conflict Resolution ---
+                    // --- conflict resolution ---
                     frame.show(ui, |ui| {
                         ui.set_width(ui.available_width());
                         ui.label(egui::RichText::new("Conflict Resolution").weak().small());
@@ -1276,7 +1287,7 @@ impl eframe::App for GUIApp {
 
                     ui.add_space(4.0);
 
-                    // --- Backup Location & Naming ---
+                    // --- backup location & naming ---
                     frame.show(ui, |ui| {
                         ui.set_width(ui.available_width());
                         ui.label(egui::RichText::new("Backup Location & Naming").weak().small());
@@ -1376,7 +1387,7 @@ impl eframe::App for GUIApp {
                         }
                     });
 
-                    // Apply changes to default backup location
+                    // apply the default backup location change
                     let should_update = match &self.default_backup_location {
                         Some(p) => loc_str != p.display().to_string(),
                         None => !loc_str.is_empty(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -450,7 +450,7 @@ impl eframe::App for GUIApp {
                 ui.separator();
                 ui.colored_label(egui::Color32::LIGHT_BLUE, "Backup finished. Relaunch apps?");
                 for app in &self.closed_apps {
-                    let note = if app.exe_path.is_some() { "" } else { " (failed to relaunch apps)" };
+                    let note = if app.exe_path.is_some() { "" } else { "Can't determine installation path" };
                     ui.label(format!("  • {}{}", app.name, note));
                 }
                 ui.add_space(4.0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,7 @@ struct GUIApp {
     automatic_updates: bool,
     file_size_summary: bool,
     save_to_exe_dir: bool,
+    save_template_exe_dir: bool,
     backup_name_mode: BackupNameMode,
     // temporary string buffer for the name input in settings
     backup_name_input: String,
@@ -228,6 +229,7 @@ impl Default for GUIApp {
             automatic_updates: config.automatic_updates,
             file_size_summary: false,
             save_to_exe_dir: config.save_to_exe_dir,
+            save_template_exe_dir: config.save_template_exe_dir,
             backup_name_input: match &config.backup_name_mode {
                 BackupNameMode::Timestamp(s) | BackupNameMode::Fixed(s) => s.clone(),
             },
@@ -558,23 +560,36 @@ impl eframe::App for GUIApp {
                 if ui.button("Add Path").clicked() {
                     self.template_paths.push(PathBuf::new());
                 }
-                if ui.button("Save Template").clicked()
-                    && let Some(path) = FileDialog::new().add_filter("JSON", &["json"]).save_file()
-                {
-                    let tpl = BackupTemplate {
-                        paths: self.template_paths.clone(),
+                    let save_path = if self.save_template_exe_dir {
+                    std::env::current_exe().ok()
+                        .and_then(|p| p.parent().map(|d| d.join("template.json")))
+                } else {
+                    None
+                };
+
+                if ui.button("Save Template").clicked() {
+                    let path = if self.save_template_exe_dir {
+                        save_path.clone()
+                    } else {
+                        FileDialog::new().add_filter("JSON", &["json"]).save_file()
                     };
-                    match serde_json::to_string_pretty(&tpl) {
-                        Ok(json) => {
-                            if fs::write(&path, json).is_ok() {
-                                *self.status.lock().unwrap() = "✅ Template saved".into();
-                                self.template_editor = false;
-                            } else {
-                                *self.status.lock().unwrap() = "❌ Couldn't write file.".into();
+
+                    if let Some(path) = path {
+                        let tpl = BackupTemplate {
+                            paths: self.template_paths.clone(),
+                        };
+                        match serde_json::to_string_pretty(&tpl) {
+                            Ok(json) => {
+                                if fs::write(&path, json).is_ok() {
+                                    *self.status.lock().unwrap() = "✅ Template saved".into();
+                                    self.template_editor = false;
+                                } else {
+                                    *self.status.lock().unwrap() = "❌ Couldn't write file.".into();
+                                }
                             }
-                        }
-                        Err(_) => {
-                            *self.status.lock().unwrap() = "❌ Failed to serialize.".into();
+                            Err(_) => {
+                                *self.status.lock().unwrap() = "❌ Failed to serialize.".into();
+                            }
                         }
                     }
                 }
@@ -924,12 +939,17 @@ impl eframe::App for GUIApp {
                                         }
                                 });
 
-                            ui.add_sized(btn_size, egui::Button::new("Save Template"))
+                                ui.add_sized(btn_size, egui::Button::new("Save Template"))
                                 .clicked()
                                 .then(|| {
-                                    if let Some(path) =
+                                    let path = if self.save_template_exe_dir {
+                                        std::env::current_exe().ok()
+                                            .and_then(|p| p.parent().map(|d| d.join("template.json")))
+                                    } else {
                                         FileDialog::new().add_filter("JSON", &["json"]).save_file()
-                                    {
+                                    };
+
+                                    if let Some(path) = path {
                                         let template = BackupTemplate {
                                             paths: self.selected_folders.clone(),
                                         };
@@ -1184,6 +1204,7 @@ impl eframe::App for GUIApp {
                         ui.add_space(2.0);
 
                         ui.checkbox(&mut self.save_to_exe_dir, "Save backups to exe directory");
+                        ui.checkbox(&mut self.save_template_exe_dir, "Save templates to exe directory");
                         ui.add_space(2.0);
 
                         ui.label("Default backup location:");
@@ -1302,6 +1323,7 @@ impl eframe::App for GUIApp {
                             self.config.automatic_updates = self.automatic_updates;
                             self.config.file_size_summary = self.file_size_summary;
                             self.config.save_to_exe_dir = self.save_to_exe_dir;
+                            self.config.save_template_exe_dir = self.save_template_exe_dir;
                             self.config.backup_name_mode = self.backup_name_mode.clone();
                             self.config.save();
                             *self.status.lock().unwrap() = "✅ Settings saved".into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,13 @@ use helpers::ConflictResolutionMode;
 use helpers::Progress;
 use helpers::build_human_tree;
 use helpers::collect_paths;
+use helpers::exe_dir;
 use helpers::fix_skip;
+use helpers::init_crash_log;
 use helpers::load_icon_image;
 use helpers::parse_fingerprint;
 use helpers::render_tree;
 use helpers::verbose_log_path;
-use helpers::init_crash_log;
-use helpers::exe_dir;
 use restore::{ConflictAnswer, restore_backup};
 
 use std::{
@@ -27,10 +27,6 @@ use std::{
     sync::{Arc, Mutex, mpsc},
     thread,
 };
-//#[cfg(target_os = "windows")]
-//use std::os::windows::process::CommandExt;
-//#[cfg(target_os = "windows")]
-//const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 use chrono::Local;
 use eframe::egui;
@@ -46,13 +42,34 @@ struct KnownApp {
 }
 
 const KNOWN_APPS: &[KnownApp] = &[
-    KnownApp { name: "Discord / Vesktop", process: "vesktop.exe"},
-    KnownApp { name: "Discord",           process: "Discord.exe"},
-    KnownApp { name: "Steam",             process: "steam.exe"},
-    KnownApp { name: "OBS Studio",        process: "obs64.exe"},
-    KnownApp { name: "Zen Browser",       process: "zen.exe"},
-    KnownApp { name: "Spotify",           process: "Spotify.exe"},
-    KnownApp { name: "ShareX",            process: "ShareX.exe"},
+    KnownApp {
+        name: "Discord / Vesktop",
+        process: "vesktop.exe",
+    },
+    KnownApp {
+        name: "Discord",
+        process: "Discord.exe",
+    },
+    KnownApp {
+        name: "Steam",
+        process: "steam.exe",
+    },
+    KnownApp {
+        name: "OBS Studio",
+        process: "obs64.exe",
+    },
+    KnownApp {
+        name: "Zen Browser",
+        process: "zen.exe",
+    },
+    KnownApp {
+        name: "Spotify",
+        process: "Spotify.exe",
+    },
+    KnownApp {
+        name: "ShareX",
+        process: "ShareX.exe",
+    },
 ];
 
 struct ClosedApp {
@@ -91,28 +108,6 @@ struct FolderTreeNode {
     children: HashMap<String, FolderTreeNode>,
     checked: bool,
     is_file: bool,
-}
-
-/// Build a [`FolderTreeNode`] tree from a flat list of path strings.
-#[allow(dead_code)]
-fn build_tree_from_paths(paths: &[String]) -> FolderTreeNode {
-    let mut root = FolderTreeNode::default();
-    for path in paths {
-        let mut current = &mut root;
-        for part in Path::new(path).components() {
-            let key = part.as_os_str().to_string_lossy().to_string();
-            current = current
-                .children
-                .entry(key.clone())
-                .or_insert(FolderTreeNode {
-                    children: HashMap::new(),
-                    checked: true,
-                    is_file: false,
-                });
-        }
-        current.is_file = true;
-    }
-    root
 }
 
 /// Entry point
@@ -276,14 +271,14 @@ impl GUIApp {
             // the selected backup folders — ignores apps that aren't relevant.
             let locked_names = helpers::processes_locking_paths(&folders, verbose);
 
-            let process_names: Vec<&'static str> =
-                KNOWN_APPS.iter().map(|a| a.process).collect();
+            let process_names: Vec<&'static str> = KNOWN_APPS.iter().map(|a| a.process).collect();
 
             // Only keep apps that are both running AND locking something we're backing up.
             let detected = helpers::detect_known_processes(&process_names)
                 .into_iter()
                 .filter(|(i, _)| {
-                    let exe_stem = KNOWN_APPS[*i].process
+                    let exe_stem = KNOWN_APPS[*i]
+                        .process
                         .trim_end_matches(".exe")
                         .to_lowercase();
                     locked_names.iter().any(|locked| {
@@ -362,7 +357,14 @@ impl GUIApp {
             .name("konserve-backup".into())
             .stack_size(8 * 1024 * 1024)
             .spawn(move || {
-                match backup_gui(&folders, &out_dir, &filename, &progress, verbose, skip_locked) {
+                match backup_gui(
+                    &folders,
+                    &out_dir,
+                    &filename,
+                    &progress,
+                    verbose,
+                    skip_locked,
+                ) {
                     Ok(path) => {
                         *status.lock().unwrap() = format!("✅ Backup created:\n{}", path.display());
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use helpers::parse_fingerprint;
 use helpers::render_tree;
 use helpers::verbose_log_path;
 use helpers::init_crash_log;
+use helpers::exe_dir;
 use restore::{ConflictAnswer, restore_backup};
 
 use std::{
@@ -543,7 +544,7 @@ impl eframe::App for GUIApp {
 
                                 // Browse for folder
                                 if ui.button("Browse").clicked()
-                                    && let Some(p) = FileDialog::new().pick_folder()
+                                    && let Some(p) = FileDialog::new().set_directory(exe_dir()).pick_folder()
                                 {
                                     *path = p;
                                 }
@@ -573,7 +574,7 @@ impl eframe::App for GUIApp {
                     let path = if self.save_template_exe_dir {
                         save_path.clone()
                     } else {
-                        FileDialog::new().add_filter("JSON", &["json"]).save_file()
+                        FileDialog::new().set_directory(exe_dir()).add_filter("JSON", &["json"]).save_file()
                     };
 
                     if let Some(path) = path {
@@ -774,7 +775,7 @@ impl eframe::App for GUIApp {
                             #[cfg(target_os = "macos")]
                             {
                                 // macOS wants dialogs on the main thread
-                                if let Some(folders) = FileDialog::new().pick_folders() {
+                                if let Some(folders) = FileDialog::new().set_directory(exe_dir()).pick_folders() {
                                     self.selected_folders.extend(folders);
                                     self.selected_folders.sort();
                                     self.selected_folders.dedup();
@@ -792,7 +793,7 @@ impl eframe::App for GUIApp {
 
                                     std::thread::spawn(move || {
                                         let folders =
-                                            FileDialog::new().pick_folders().unwrap_or_default();
+                                            FileDialog::new().set_directory(exe_dir()).pick_folders().unwrap_or_default();
                                         let _ = tx.send(folders);
                                     });
                                 }
@@ -802,7 +803,7 @@ impl eframe::App for GUIApp {
                         if ui.button("Add Files").clicked() {
                             #[cfg(target_os = "macos")]
                             {
-                                if let Some(files) = FileDialog::new().pick_files() {
+                                if let Some(files) = FileDialog::new().set_directory(exe_dir()).pick_files() {
                                     self.selected_folders.extend(files);
                                     self.selected_folders.sort();
                                     self.selected_folders.dedup();
@@ -819,7 +820,7 @@ impl eframe::App for GUIApp {
 
                                     std::thread::spawn(move || {
                                         let files =
-                                            FileDialog::new().pick_files().unwrap_or_default();
+                                            FileDialog::new().set_directory(exe_dir()).pick_files().unwrap_or_default();
                                         let _ = tx.send(files);
                                     });
                                 }
@@ -907,7 +908,7 @@ impl eframe::App for GUIApp {
                                         std::env::current_exe().ok()
                                             .and_then(|p| p.parent().map(|d| d.join("template.json")))
                                     } else {
-                                        FileDialog::new().add_filter("JSON", &["json"]).pick_file()
+                                        FileDialog::new().set_directory(exe_dir()).add_filter("JSON", &["json"]).pick_file()
                                     };
 
                                     if let Some(path) = path
@@ -954,7 +955,7 @@ impl eframe::App for GUIApp {
                                         std::env::current_exe().ok()
                                             .and_then(|p| p.parent().map(|d| d.join("template.json")))
                                     } else {
-                                        FileDialog::new().add_filter("JSON", &["json"]).save_file()
+                                        FileDialog::new().set_directory(exe_dir()).add_filter("JSON", &["json"]).save_file()
                                     };
 
                                     if let Some(path) = path {
@@ -994,7 +995,8 @@ impl eframe::App for GUIApp {
                                         std::env::current_exe().ok()
                                             .and_then(|p| p.parent().map(|d| d.to_path_buf()))
                                     } else {
-                                        FileDialog::new()
+                                        FileDialog::new().set_directory(exe_dir())
+
                                             .set_title("Choose backup destination")
                                             .pick_folder()
                                     };
@@ -1029,7 +1031,7 @@ impl eframe::App for GUIApp {
                                 .clicked()
                                 .then(|| {
                                     let status = self.status.clone();
-                                    if let Some(zip_file) = FileDialog::new()
+                                    if let Some(zip_file) = FileDialog::new().set_directory(exe_dir())
                                         .add_filter("Tar archives", &["tar", "tar.gz"])
                                         .pick_file()
                                     {
@@ -1127,7 +1129,7 @@ impl eframe::App for GUIApp {
                                 std::env::current_exe().ok()
                                     .and_then(|p| p.parent().map(|d| d.join("template.json")))
                             } else {
-                                FileDialog::new().add_filter("JSON", &["json"]).pick_file()
+                                FileDialog::new().set_directory(exe_dir()).add_filter("JSON", &["json"]).pick_file()
                             };
 
                             if let Some(path) = path
@@ -1226,7 +1228,7 @@ impl eframe::App for GUIApp {
                         ui.add_sized([ui.available_width(), 20.0], egui::TextEdit::singleline(&mut loc_str));
                         ui.horizontal(|ui| {
                             if ui.small_button("Browse").clicked()
-                                && let Some(folder) = rfd::FileDialog::new().pick_folder()
+                                && let Some(folder) = rfd::FileDialog::new().set_directory(exe_dir()).pick_folder()
                             {
                                 loc_str = folder.display().to_string();
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,7 +328,6 @@ impl GUIApp {
         out_dir: PathBuf,
         filename: String,
         skip_locked: bool,
-        relaunch: Vec<&'static str>,
     ) {
         let status = self.status.clone();
         let progress = Progress::default();
@@ -349,9 +348,6 @@ impl GUIApp {
                         clog!("ERROR: backup failed: {e}");
                         *status.lock().unwrap() = format!("❌ Backup failed: {e}");
                     }
-                }
-                for exe in relaunch {
-                    let _ = std::process::Command::new(exe).spawn();
                 }
             })
             .expect("failed to spawn backup thread");
@@ -440,7 +436,7 @@ impl eframe::App for GUIApp {
                     }
                     if ui.button("Skip locked files").clicked() {
                         let pending = self.pending_backup.take().unwrap();
-                        self.start_backup(pending.folders, pending.out_dir, pending.filename, true, vec![]);
+                        self.start_backup(pending.folders, pending.out_dir, pending.filename, true);
                     }
                     if ui.button("Cancel").clicked() {
                         self.pending_backup = None;
@@ -668,7 +664,7 @@ impl eframe::App for GUIApp {
                         self.detect_rx = None;
                         self.detecting_apps = false;
                         if detected.is_empty() {
-                            self.start_backup(folders, out_dir, filename, false, vec![]);
+                            self.start_backup(folders, out_dir, filename, false);
                         } else {
                             *self.status.lock().unwrap() = "Waiting…".into();
                             self.pending_backup = Some(PendingBackup { folders, out_dir, filename, detected });

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,7 @@ const KNOWN_APPS: &[KnownApp] = &[
 ];
 
 struct ClosedApp {
-    /// Display name shown in the prompt.
-    name: &'static str,
+    known_index: usize,
     /// Executable path to relaunch after backup (Windows only).
     exe_path: Option<PathBuf>,
 }
@@ -297,9 +296,8 @@ impl GUIApp {
             .spawn(move || {
                 let mut actually_closed: Vec<ClosedApp> = Vec::new();
                 for app in apps {
-                    let proc = KNOWN_APPS.iter().find(|k| k.name == app.name).map(|k| k.process);
-                    let killed = proc.map(helpers::kill_process).unwrap_or(false);
-                    if killed {
+                    let proc = KNOWN_APPS[app.known_index].process;
+                    if helpers::kill_process(proc) {
                         actually_closed.push(app);
                     }
                 }
@@ -428,7 +426,7 @@ impl eframe::App for GUIApp {
                         let pending = self.pending_backup.take().unwrap();
                         let apps: Vec<ClosedApp> = pending.detected.iter()
                             .map(|&(i, ref path)| ClosedApp {
-                                name: KNOWN_APPS[i].name,
+                                known_index: i,
                                 exe_path: path.clone(),
                             })
                             .collect();
@@ -451,7 +449,7 @@ impl eframe::App for GUIApp {
                 ui.colored_label(egui::Color32::LIGHT_BLUE, "Backup finished. Relaunch apps?");
                 for app in &self.closed_apps {
                     let note = if app.exe_path.is_some() { "" } else { "Can't determine installation path" };
-                    ui.label(format!("  • {}{}", app.name, note));
+                    ui.label(format!("  • {}{}", KNOWN_APPS[app.known_index].name, note));
                 }
                 ui.add_space(4.0);
                 ui.horizontal(|ui| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,11 +288,6 @@ impl GUIApp {
 
         *status.lock().unwrap() = "Closing apps…".into();
 
-        let process_names: Vec<&'static str> = apps
-            .iter()
-            .filter_map(|a| KNOWN_APPS.iter().find(|k| k.name == a.name).map(|k| k.process))
-            .collect();
-
         let (done_tx, done_rx) = mpsc::channel::<Vec<ClosedApp>>();
         self.relaunch_rx = Some(done_rx);
 
@@ -300,8 +295,13 @@ impl GUIApp {
             .name("konserve-backup".into())
             .stack_size(8 * 1024 * 1024)
             .spawn(move || {
-                for proc in &process_names {
-                    helpers::kill_process(proc);
+                let mut actually_closed: Vec<ClosedApp> = Vec::new();
+                for app in apps {
+                    let proc = KNOWN_APPS.iter().find(|k| k.name == app.name).map(|k| k.process);
+                    let killed = proc.map(helpers::kill_process).unwrap_or(false);
+                    if killed {
+                        actually_closed.push(app);
+                    }
                 }
                 std::thread::sleep(std::time::Duration::from_millis(800));
 
@@ -316,7 +316,7 @@ impl GUIApp {
                     }
                 }
 
-                let _ = done_tx.send(apps);
+                let _ = done_tx.send(actually_closed);
             })
             .expect("failed to spawn backup thread");
     }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -191,13 +191,13 @@ pub fn restore_backup(
         // If selection is active, skip entries that don't match exactly or aren't
         // inside a selected top-level folder (uuid/ prefix).
         if selected.is_some()
-    && !to_extract.contains(&path_in_tar)
-    && !to_extract.iter().any(|s| {
-        path_in_tar.len() > s.len()
-            && path_in_tar.as_bytes()[s.len()] == b'/'
-            && path_in_tar.starts_with(s.as_str())
-    })
-{
+            && !to_extract.contains(&path_in_tar)
+            && !to_extract.iter().any(|s| {
+                path_in_tar.len() > s.len()
+                    && path_in_tar.as_bytes()[s.len()] == b'/'
+                    && path_in_tar.starts_with(s.as_str())
+            })
+        {
             if verbose {
                 dlog!("[skip]    {path_in_tar}  (not selected)");
             }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1,6 +1,6 @@
-﻿//! Extracts `.tar` backups, validates the fingerprint, and reconstructs original file paths.
+﻿//! unpacks .tar backups, checks the fingerprint, puts files back where they came from
 use crate::helpers::{ConflictResolutionMode, Progress, adjust_path, get_fingered};
-use crate::{clog, dlog};
+use crate::{dlog, elog};
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File},
@@ -10,14 +10,14 @@ use std::{
 };
 use tar::Archive;
 
-/// Per-file answer sent from the UI back to a paused restore thread.
+/// what the user picked when a restore hits a conflict, sent back from the ui
 pub enum ConflictAnswer {
     Overwrite,
     Skip,
     Rename,
 }
 
-/// Return the path to write to, or `None` to skip the file.
+/// figures out where to actually write, or None if we're skipping it
 fn resolve_conflict(
     dest: &Path,
     mode: ConflictResolutionMode,
@@ -48,7 +48,7 @@ fn resolve_conflict(
     }
 }
 
-/// Append `_1`, `_2`, … before the extension until a free path is found.
+/// tacks on _1, _2 etc before the extension till we find a free name
 fn unique_path(dest: &Path) -> PathBuf {
     let stem = dest.file_stem().unwrap_or_default().to_string_lossy();
     let ext = dest
@@ -66,12 +66,12 @@ fn unique_path(dest: &Path) -> PathBuf {
     }
 }
 
-/// Normalize path separators to `/` for consistent comparison.
+/// swap backslashes for / so paths compare consistently
 fn canon<S: AsRef<str>>(s: S) -> String {
     s.as_ref().replace('\\', "/")
 }
 
-/// Restore files from a `.tar` archive. If `selected` is provided, only those paths are restored.
+/// restores from the tar, if selected is given only those paths get restored
 pub fn restore_backup(
     zip_path: &PathBuf,
     selected: Option<Vec<String>>,
@@ -83,10 +83,9 @@ pub fn restore_backup(
 ) -> Result<(), String> {
     *status.lock().unwrap() = "Restoring backup…".into();
 
-    // Open archive and locate fingerprint
     let mut archive = Archive::new(File::open(zip_path).map_err(|e| {
         let msg = format!("ERROR: cannot open archive {}: {e}", zip_path.display());
-        clog!("{msg}");
+        elog!("{msg}");
         msg
     })?);
     let mut path_map: HashMap<String, PathBuf> = HashMap::new();
@@ -97,12 +96,11 @@ pub fn restore_backup(
         let header_path = entry.path().map_err(|e| e.to_string())?;
         let entry_name = header_path.to_string_lossy();
 
-        // Parse fingerprint.txt to reconstruct UUID mappings
         if entry_name == "fingerprint.txt" {
             let mut txt = String::new();
             entry.read_to_string(&mut txt).map_err(|e| e.to_string())?;
 
-            // Abort if the fingerprint marker doesn't match the expected build
+            // bail if the fingerprint doesn't match this build
             if txt.contains(get_fingered()) {
                 valid_fingerprint = true;
 
@@ -117,7 +115,7 @@ pub fn restore_backup(
     }
 
     if !valid_fingerprint {
-        clog!(
+        elog!(
             "ERROR: restore aborted — invalid or missing backup fingerprint in {}",
             zip_path.display()
         );
@@ -155,7 +153,7 @@ pub fn restore_backup(
         }
     }
 
-    // Count is tracked during extraction to avoid a second full archive pass.
+    // counting as we go so we don't have to walk the archive twice
     let mut total_files: u32 = 1;
     let mut done: u32 = 0;
 
@@ -163,14 +161,13 @@ pub fn restore_backup(
         dlog!("[select]  to_extract = {to_extract:?}");
     }
 
-    // Begin extraction
     let current_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("C:\\"));
     let mut archive = Archive::new(File::open(zip_path).map_err(|e| {
         let msg = format!(
             "ERROR: cannot reopen archive for extraction {}: {e}",
             zip_path.display()
         );
-        clog!("{msg}");
+        elog!("{msg}");
         msg
     })?);
 
@@ -188,8 +185,8 @@ pub fn restore_backup(
             continue;
         }
 
-        // If selection is active, skip entries that don't match exactly or aren't
-        // inside a selected top-level folder (uuid/ prefix).
+        // if a selection was given, skip anything that's not an exact match or
+        // inside a selected folder (uuid/ prefix)
         if selected.is_some()
             && !to_extract.contains(&path_in_tar)
             && !to_extract.iter().any(|s| {
@@ -217,7 +214,7 @@ pub fn restore_backup(
             }
         };
 
-        // Case 1: UUID prefix = folder root
+        // uuid prefix = folder root
         if let Some(orig_base) = path_map.get(&root_component) {
             let adjusted_base = adjust_path(orig_base, &current_home, verbose);
             let rel = tar_path
@@ -233,7 +230,7 @@ pub fn restore_backup(
                 if let Some(dir) = final_path.parent() {
                     fs::create_dir_all(dir).map_err(|e| {
                         let msg = format!("ERROR: failed to create dir {}: {e}", dir.display());
-                        clog!("{msg}");
+                        elog!("{msg}");
                         msg
                     })?;
                 }
@@ -243,7 +240,7 @@ pub fn restore_backup(
                         path_in_tar,
                         final_path.display()
                     );
-                    clog!("{msg}");
+                    elog!("{msg}");
                     msg
                 })?;
                 restored_count += 1;
@@ -255,7 +252,7 @@ pub fn restore_backup(
             done += 1;
             progress.set((done * 100) / total_files);
         }
-        // Case 2: UUID.ext = standalone file
+        // uuid.ext = standalone file
         else if let Some((uuid_part, _ext)) = root_component.split_once('.') {
             if let Some(orig_file) = path_map.get(uuid_part) {
                 let unpack_to = adjust_path(orig_file, &current_home, verbose);
@@ -267,7 +264,7 @@ pub fn restore_backup(
                     if let Some(dir) = final_path.parent() {
                         fs::create_dir_all(dir).map_err(|e| {
                             let msg = format!("ERROR: failed to create dir {}: {e}", dir.display());
-                            clog!("{msg}");
+                            elog!("{msg}");
                             msg
                         })?;
                     }
@@ -277,7 +274,7 @@ pub fn restore_backup(
                             path_in_tar,
                             final_path.display()
                         );
-                        clog!("{msg}");
+                        elog!("{msg}");
                         msg
                     })?;
                     restored_count += 1;

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1,6 +1,6 @@
 ﻿//! Extracts `.tar` backups, validates the fingerprint, and reconstructs original file paths.
 use crate::helpers::{ConflictResolutionMode, Progress, adjust_path, get_fingered};
-use crate::{dlog, clog};
+use crate::{clog, dlog};
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File},
@@ -86,7 +86,8 @@ pub fn restore_backup(
     // Open archive and locate fingerprint
     let mut archive = Archive::new(File::open(zip_path).map_err(|e| {
         let msg = format!("ERROR: cannot open archive {}: {e}", zip_path.display());
-        clog!("{msg}"); msg
+        clog!("{msg}");
+        msg
     })?);
     let mut path_map: HashMap<String, PathBuf> = HashMap::new();
     let mut valid_fingerprint = false;
@@ -116,11 +117,16 @@ pub fn restore_backup(
     }
 
     if !valid_fingerprint {
-        clog!("ERROR: restore aborted — invalid or missing backup fingerprint in {}", zip_path.display());
+        clog!(
+            "ERROR: restore aborted — invalid or missing backup fingerprint in {}",
+            zip_path.display()
+        );
         return Err("Invalid backup fingerprint.".into());
     }
 
-    if verbose { dlog!("[fingerprint] loaded, {} uuids", path_map.len()); }
+    if verbose {
+        dlog!("[fingerprint] loaded, {} uuids", path_map.len());
+    }
 
     let mut to_extract: HashSet<String> = HashSet::new();
 
@@ -153,16 +159,24 @@ pub fn restore_backup(
     let mut total_files: u32 = 1;
     let mut done: u32 = 0;
 
-    if verbose { dlog!("[select]  to_extract = {to_extract:?}"); }
+    if verbose {
+        dlog!("[select]  to_extract = {to_extract:?}");
+    }
 
     // Begin extraction
     let current_home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("C:\\"));
     let mut archive = Archive::new(File::open(zip_path).map_err(|e| {
-        let msg = format!("ERROR: cannot reopen archive for extraction {}: {e}", zip_path.display());
-        clog!("{msg}"); msg
+        let msg = format!(
+            "ERROR: cannot reopen archive for extraction {}: {e}",
+            zip_path.display()
+        );
+        clog!("{msg}");
+        msg
     })?);
 
-    if verbose { dlog!("[extract] scanning archive…"); }
+    if verbose {
+        dlog!("[extract] scanning archive…");
+    }
     let mut restored_count = 0;
 
     for entry_res in archive.entries().map_err(|e| e.to_string())? {
@@ -178,9 +192,13 @@ pub fn restore_backup(
         // inside a selected top-level folder (uuid/ prefix).
         if selected.is_some()
             && !to_extract.contains(&path_in_tar)
-            && !to_extract.iter().any(|s| path_in_tar.starts_with(&format!("{s}/")))
+            && !to_extract
+                .iter()
+                .any(|s| path_in_tar.starts_with(&format!("{s}/")))
         {
-            if verbose { dlog!("[skip]    {path_in_tar}  (not selected)"); }
+            if verbose {
+                dlog!("[skip]    {path_in_tar}  (not selected)");
+            }
             continue;
         }
 
@@ -190,7 +208,9 @@ pub fn restore_backup(
         let root_component = match tar_path.components().next() {
             Some(c) => c.as_os_str().to_string_lossy().into_owned(),
             None => {
-                if verbose { dlog!("[skip]    {path_in_tar}  (empty path)"); }
+                if verbose {
+                    dlog!("[skip]    {path_in_tar}  (empty path)");
+                }
                 continue;
             }
         };
@@ -203,22 +223,32 @@ pub fn restore_backup(
                 .unwrap_or_else(|_| Path::new(""));
 
             let unpack_to = adjusted_base.join(rel);
-            if verbose { dlog!("[write] dir {path_in_tar}  →  {}", unpack_to.display()); }
+            if verbose {
+                dlog!("[write] dir {path_in_tar}  →  {}", unpack_to.display());
+            }
 
             if let Some(final_path) = resolve_conflict(&unpack_to, mode, &conflict_ch) {
                 if let Some(dir) = final_path.parent() {
                     fs::create_dir_all(dir).map_err(|e| {
                         let msg = format!("ERROR: failed to create dir {}: {e}", dir.display());
-                        clog!("{msg}"); msg
+                        clog!("{msg}");
+                        msg
                     })?;
                 }
                 entry.unpack(&final_path).map_err(|e| {
-                    let msg = format!("ERROR: failed to unpack {} → {}: {e}", path_in_tar, final_path.display());
-                    clog!("{msg}"); msg
+                    let msg = format!(
+                        "ERROR: failed to unpack {} → {}: {e}",
+                        path_in_tar,
+                        final_path.display()
+                    );
+                    clog!("{msg}");
+                    msg
                 })?;
                 restored_count += 1;
             } else {
-                if verbose { dlog!("[skip] conflict: {}", unpack_to.display()); }
+                if verbose {
+                    dlog!("[skip] conflict: {}", unpack_to.display());
+                }
             }
             done += 1;
             progress.set((done * 100) / total_files);
@@ -227,36 +257,51 @@ pub fn restore_backup(
         else if let Some((uuid_part, _ext)) = root_component.split_once('.') {
             if let Some(orig_file) = path_map.get(uuid_part) {
                 let unpack_to = adjust_path(orig_file, &current_home, verbose);
-                if verbose { dlog!("[write] file {path_in_tar}  →  {}", unpack_to.display()); }
+                if verbose {
+                    dlog!("[write] file {path_in_tar}  →  {}", unpack_to.display());
+                }
 
                 if let Some(final_path) = resolve_conflict(&unpack_to, mode, &conflict_ch) {
                     if let Some(dir) = final_path.parent() {
                         fs::create_dir_all(dir).map_err(|e| {
                             let msg = format!("ERROR: failed to create dir {}: {e}", dir.display());
-                            clog!("{msg}"); msg
+                            clog!("{msg}");
+                            msg
                         })?;
                     }
                     entry.unpack(&final_path).map_err(|e| {
-                        let msg = format!("ERROR: failed to unpack {} → {}: {e}", path_in_tar, final_path.display());
-                        clog!("{msg}"); msg
+                        let msg = format!(
+                            "ERROR: failed to unpack {} → {}: {e}",
+                            path_in_tar,
+                            final_path.display()
+                        );
+                        clog!("{msg}");
+                        msg
                     })?;
                     restored_count += 1;
                 } else {
-                    if verbose { dlog!("[skip] conflict: {}", unpack_to.display()); }
+                    if verbose {
+                        dlog!("[skip] conflict: {}", unpack_to.display());
+                    }
                 }
                 done += 1;
                 progress.set((done * 100) / total_files);
             } else {
-                if verbose { dlog!("[skip]    {path_in_tar}  (uuid not in map)"); }
+                if verbose {
+                    dlog!("[skip]    {path_in_tar}  (uuid not in map)");
+                }
             }
         } else {
-            if verbose { dlog!("[skip]    {path_in_tar}  (no handler)"); }
+            if verbose {
+                dlog!("[skip]    {path_in_tar}  (no handler)");
+            }
         }
     }
 
-    if verbose { dlog!("[done]   restored {restored_count} entries"); }
+    if verbose {
+        dlog!("[done]   restored {restored_count} entries");
+    }
     *status.lock().unwrap() = "✅ Restore complete.".into();
     progress.done();
     Ok(())
 }
-

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -191,11 +191,13 @@ pub fn restore_backup(
         // If selection is active, skip entries that don't match exactly or aren't
         // inside a selected top-level folder (uuid/ prefix).
         if selected.is_some()
-            && !to_extract.contains(&path_in_tar)
-            && !to_extract
-                .iter()
-                .any(|s| path_in_tar.starts_with(&format!("{s}/")))
-        {
+    && !to_extract.contains(&path_in_tar)
+    && !to_extract.iter().any(|s| {
+        path_in_tar.len() > s.len()
+            && path_in_tar.as_bytes()[s.len()] == b'/'
+            && path_in_tar.starts_with(s.as_str())
+    })
+{
             if verbose {
                 dlog!("[skip]    {path_in_tar}  (not selected)");
             }


### PR DESCRIPTION
NEW:
- added an option to save/load templates from exe root
- file dialogs default to exe root
- dropping files/folders now add paths without the need of filedialog

CHANGES:
- config now saves next to the exe instead of appdata
- switched from wmic to powershell for app detection, prompts relaunch after closing stuff
- closed_app tracking uses index now instead of matching by name
- cleaned up relaunch wording for apps with unknown paths
- dropped an unused param from start_backup
- bumped eframe 0.34.3 -> 0.35.0, png 0.18 -> 0.18.1
- version bump to 0.1.11
- detect apps locking backup

FIXES:
- crash log only gets created on first write now, not at startup
- no more duplicate sub-processes showing up in app detection
- kill_process actually returns success/fail properly now, also fixed a typo in the non-windows fn
- only relaunches apps that were actually killed
- relaunch_rx doesn't hang anymore